### PR TITLE
typo in pygeom_active_detector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requires-python = ">=3.9"
 dependencies = [
     "legend-pygeom-hpges",
     "legend-pygeom-optics",
-    "legend-pygeom-tools>=0.0.3",
+    "legend-pygeom-tools>=0.0.6",
     "numpy",
     "pint",
     "pyg4ometry",

--- a/src/l1000geom/fibers.py
+++ b/src/l1000geom/fibers.py
@@ -280,7 +280,7 @@ class ModuleFactoryBase(ABC):
             mother_lv,
             self.registry,
         )
-        sipm_pv.pygeom_active_dector = RemageDetectorInfo("optical", sipm_detector_id)
+        sipm_pv.pygeom_active_detector = RemageDetectorInfo("optical", sipm_detector_id)
         # Add border surface to mother volume.
         g4.BorderSurface(
             f"bsurface_lar_{sipm_name}",
@@ -688,7 +688,7 @@ class ModuleFactorySingleFibers(ModuleFactoryBase):
                 mother_lv,
                 self.registry,
             )
-            sipm_pv.pygeom_active_dector = RemageDetectorInfo("optical", mod.channel_bottom_rawid)
+            sipm_pv.pygeom_active_detector = RemageDetectorInfo("optical", mod.channel_bottom_rawid)
             # Add border surface to mother volume.
             g4.BorderSurface(
                 f"bsurface_lar_{mod.channel_bottom_name}",

--- a/src/l1000geom/hpge_strings.py
+++ b/src/l1000geom/hpge_strings.py
@@ -124,7 +124,7 @@ def _place_hpge_string(
             b.mother_lv,
             b.registry,
         )
-        det_pv.pygeom_active_dector = RemageDetectorInfo("germanium", det_unit.rawid, det_unit.meta)
+        det_pv.pygeom_active_detector = RemageDetectorInfo("germanium", det_unit.rawid, det_unit.meta)
         det_unit.lv.pygeom_color_rgba = (0, 1, 1, 1)
 
         # add germanium reflective surface.


### PR DESCRIPTION
the old name has been deprecated in `legend-pygeom-tools` today, fix it also here to avoid deprecation warnings in CI.

see https://github.com/legend-exp/legend-pygeom-l200/pull/83 and https://github.com/legend-exp/legend-pygeom-tools/pull/11