### PR TITLE
Add timestamp to metadata_generator

### DIFF
--- a/misc/dummy_metadata_generator.py
+++ b/misc/dummy_metadata_generator.py
@@ -151,7 +151,8 @@ def main():
         len(ARRAY_CONFIG["center"]["x_in_mm"]) * len(ARRAY_CONFIG["angle_in_deg"])
     ).reshape(len(ARRAY_CONFIG["center"]["x_in_mm"]), len(ARRAY_CONFIG["angle_in_deg"]))
 
-    chm = legendmeta.LegendMetadata().channelmap()
+    timestamp = "20230125T212014Z"
+    chm = legendmeta.LegendMetadata().channelmap(on=timestamp)
     hpge_data = chm[config["dummy_dets"]["hpge"]]
     hpge_names = np.sort(
         np.concatenate(


### PR DESCRIPTION
If you run the metadata_generator right now it will not work. Cause at the current moment only SiPMS are in the metadata.

This adds a timestamp to a point where all detector systems are in the metadata, so that this will work independent of what happens in future points in time.