### PR TITLE
Change nmoderator default to simple while the stl is broken

### DIFF
--- a/src/l1000geom/configs/special_metadata.yaml
+++ b/src/l1000geom/configs/special_metadata.yaml
@@ -21,7 +21,7 @@ detail:
     front-end_and_insulators: place
     labs: omit
     nm_holding_structure: simple
-    nm_plastic: stl
+    nm_plastic: simple
     watertank: omit
     watertank_instrumentation: omit
 fibers:


### PR DESCRIPTION
The default version should not produce any overlaps. The `nm_plastic` stl version seems to produce overlaps.