### PR TITLE
Fix reentrance tube overlap and reduce skirt gap

### DIFF
--- a/src/l1000geom/cryo.py
+++ b/src/l1000geom/cryo.py
@@ -482,6 +482,9 @@ def construct_moderator_simple(
     # Could import this if we wanted, but maybe this method has enough arguments already...
 
 
+NECKRADIUS_START = 1200
+
+
 def construct_and_place_cryostat(instr: core.InstrumentationData) -> g4.PhysicalVolume:
     if "cryostat" not in instr.detail:
         msg = "No 'cryostat' detail specified in the special metadata."
@@ -495,7 +498,7 @@ def construct_and_place_cryostat(instr: core.InstrumentationData) -> g4.Physical
     totalheight = 10000  # 10200
     neckheight = 1940  # 2000
     bodyheight = 7750  # 8000 #7000
-    neckradius = 1200
+    neckradius = NECKRADIUS_START
     # neckradius = 1900 / 2. # 1.9m diameter
     # barrelradius = 3800
     shoulderfraction = 0.233
@@ -530,16 +533,18 @@ def construct_and_place_cryostat(instr: core.InstrumentationData) -> g4.Physical
 
     skirtheight = totalheight - neckheight - (bodyheight * (1 - bottomfraction))
     skirtradius = barrelradius
-    skirtz = -bodyheight / 2 - ocryo_thickness * 3.2
+    # Due to the curvature of the bottom it is hard to remove exactly enough
+    # To close flush with the cryo but not have overlaps.
+    skirtz = -bodyheight / 2 - ocryo_thickness
     skirtthickness = 60  # A guess
-    footheight = 150
+    footheight = 250
     footwidth = 150  # Not really a guess so much as a placeholder...
 
     skirt_solid = g4.solid.Tubs(
         "skirt_sol",
         skirtradius - skirtthickness,
         skirtradius,
-        skirtheight - (ocryo_thickness * 7),
+        skirtheight - (ocryo_thickness * 2),  # Take a little bit away to avoid overlapps with the cryo
         0,
         2 * pi,
         instr.registry,


### PR DESCRIPTION
This:
1) Fixes the reentrance tube overlap. Before:
<img width="1810" height="1102" alt="Reentrance_overlap" src="https://github.com/user-attachments/assets/8bee1be1-9a6f-4e2d-961f-4528bc878e3f" />

After (there might be a small water volume above the reentrance tube now): 
<img width="2792" height="1174" alt="Fixed_reentrance" src="https://github.com/user-attachments/assets/27d5259a-7855-4e81-b876-d9b3f10d1563" />

And it improves the skirt/foot to have a smaller gap. It is still very hard to have no gap at all and still avoid overlaps, due to the curvate of the bottom. It is probably mathematically possible to make something, that is also robust against changing the cryostat dimensions... but that would be some effort
Before:
<img width="3018" height="900" alt="Fixed_Foot" src="https://github.com/user-attachments/assets/1c59b2d1-13cb-4286-be82-381a43b1eb57" />

After:
<img width="3016" height="696" alt="foot_fixed" src="https://github.com/user-attachments/assets/f332ceff-34bf-406b-939d-9cbc9f380619" />
