### PR TITLE
PMT placement adjusts height if placed out of pit

### DIFF
--- a/src/pygeoml1000/dummy_metadata_generator.py
+++ b/src/pygeoml1000/dummy_metadata_generator.py
@@ -61,7 +61,7 @@ def calculate_and_place_pmts(channelmap: dict, pmts_data: dict, pmts_pos: dict) 
             if radius > watertank.tank_pit_radius:
                 z = watertank.tank_pit_height
 
-            channelmap[name] = copy.deepcopy(pmts_meta)
+            channelmap[name] = copy.deepcopy(pmts_data)
             channelmap[name]["daq"]["rawid"] = rawid
             rawid += 1
             channelmap[name]["name"] = name


### PR DESCRIPTION
After this PR the height of the placed floor PMTs will adjust to the floor height.

Meaning, that if the radius > than the specified PIT radius it will place it above the PIT (on floor height). With this the entire PMT setup is more or less customizable from this config file: https://github.com/legend-exp/legend-pygeom-l1000/blob/main/src/pygeoml1000/configs/config.json

You can specify any radius on the floor and you can Specify any height on the tyvek wall.

This should satisfy the requirements from the astrophyical neutrino search group.

<img width="1181" height="944" alt="image" src="https://github.com/user-attachments/assets/84b6b021-6597-458b-9cf9-b17b20449c07" />
