### PR TITLE
feat: add scintillation output to water tank

### DIFF
--- a/src/pygeoml1000/watertank.py
+++ b/src/pygeoml1000/watertank.py
@@ -320,7 +320,6 @@ def construct_and_place_tank(instr: core.InstrumentationData) -> core.Instrument
 
     water_pv.set_pygeom_active_detector(RemageDetectorInfo("scintillator", 10002, {}))
 
-
     # NamedTuples are immutable, so we need to create a copy
     return instr._replace(mother_lv=water_lv, mother_pv=water_pv, mother_z_displacement=tank_z_displacement)
 


### PR DESCRIPTION
I am aware of how silly this is. But I would really like to have the energy depositions in the water tank written out. Or is there an alternative option? It would be nice for it to be the calorimetric output scheme, though [[link](https://github.com/legend-exp/remage/pull/479)]. 