### PR TITLE
feat: adding caching a la l200

### DIFF
--- a/src/pygeoml1000/hpge_strings.py
+++ b/src/pygeoml1000/hpge_strings.py
@@ -126,19 +126,13 @@ def _place_front_end_and_insulators(
     thickness: dict,
     parts_origin: dict,
 ):
-    # add cable and clamp
-    signal_cable, signal_clamp, signal_asic = _get_signal_cable_and_asic(
-        det_unit.name,
-        thickness["cable"],
-        thickness["clamp"],
-        unit_length,
-        b.materials,
-        b.mother_lv,
-        b.registry,
-    )
-    signal_cable.pygeom_color_rgba = (0.72, 0.45, 0.2, 1)
-    signal_clamp.pygeom_color_rgba = (0.3, 0.3, 0.3, 1)
-    signal_asic.pygeom_color_rgba = (0.73, 0.33, 0.4, 1)
+    string_id = string_info["string_id"]
+
+    # add cable and clamp. The logical volumes only depend on the geometry, so they are shared
+    # between all detector units; only the placements below are per detector.
+    signal_cable = _get_signal_cable(thickness["cable"], unit_length, b)
+    signal_clamp = _get_signal_clamp(thickness["clamp"], b)
+    signal_asic = _get_signal_asic(b)
 
     angle_signal = math.pi * 1 / 2.0 - string_info["string_rot"]
     x_clamp, y_clamp = np.array([string_info["x_pos"], string_info["y_pos"]]) + parts_origin["signal"][
@@ -155,7 +149,7 @@ def _place_front_end_and_insulators(
         [math.pi, 0, angle_signal],
         [x_cable, y_cable, z_pos["cable"]],  # this offset of 12 is measured from the CAD file.
         signal_cable,
-        signal_cable.name + "_string_" + string_info["string_id"],
+        f"cable_signal_{det_unit.name}_string_{string_id}",
         b.mother_lv,
         b.registry,
     )
@@ -163,7 +157,7 @@ def _place_front_end_and_insulators(
         [math.pi, 0, angle_signal],
         [x_clamp, y_clamp, z_pos["clamp"]],  # this offset of 12 is measured from the CAD file.
         signal_clamp,
-        signal_clamp.name + "_string_" + string_info["string_id"],
+        f"ultem_clamp_signal_{det_unit.name}_string_{string_id}",
         b.mother_lv,
         b.registry,
     )
@@ -175,22 +169,13 @@ def _place_front_end_and_insulators(
             z_pos["cable"] - thickness["cable"] - 0.5,
         ],  # this offset of 12 is measured from the CAD file.
         signal_asic,
-        signal_asic.name + "_string_" + string_info["string_id"],
+        f"signal_asic_{det_unit.name}_string_{string_id}",
         b.mother_lv,
         b.registry,
     )
 
-    hv_cable, hv_clamp = _get_hv_cable(
-        det_unit.name,
-        thickness["cable"],
-        thickness["clamp"],
-        unit_length,
-        b.materials,
-        b.mother_lv,
-        b.registry,
-    )
-    hv_cable.pygeom_color_rgba = (0.72, 0.45, 0.2, 1)
-    hv_clamp.pygeom_color_rgba = (0.3, 0.3, 0.3, 1)
+    hv_cable = _get_hv_cable(thickness["cable"], unit_length, b)
+    hv_clamp = _get_hv_clamp(thickness["clamp"], b)
 
     angle_hv = math.pi * 1 / 2.0 + string_info["string_rot"]
     x_clamp, y_clamp = np.array([string_info["x_pos"], string_info["y_pos"]]) - parts_origin["hv"][
@@ -204,7 +189,7 @@ def _place_front_end_and_insulators(
         [0, 0, angle_hv],
         [x_clamp, y_clamp, z_pos["cable"]],
         hv_cable,
-        hv_cable.name + "_string_" + string_info["string_id"],
+        f"cable_hv_{det_unit.name}_string_{string_id}",
         b.mother_lv,
         b.registry,
     )
@@ -212,23 +197,15 @@ def _place_front_end_and_insulators(
         [0, 0, angle_hv],
         [x_clamp, y_clamp, z_pos["clamp"]],
         hv_clamp,
-        hv_clamp.name + "_string_" + string_info["string_id"],
+        f"ultem_clamp_hv_{det_unit.name}_string_{string_id}",
         b.mother_lv,
         b.registry,
     )
 
     insulator_top_length = string_info["string_meta"].rod_radius_in_mm - det_unit.radius + 1.5
 
-    weldment, insulator = _get_weldment_and_insulator(
-        det_unit,
-        thickness["weldment"],
-        thickness["insulator"],
-        insulator_top_length,
-        b.materials,
-        b.registry,
-    )
-    weldment.pygeom_color_rgba = (0.6, 0.6, 0.6, 1)
-    insulator.pygeom_color_rgba = (0.6, 0.6, 0.6, 1)
+    weldment = _get_weldment(thickness["weldment"], b)
+    insulator = _get_insulator(thickness["insulator"], insulator_top_length, b)
 
     for i in range(3):
         copper_rod_th = np.deg2rad(-30 - i * 120)
@@ -251,7 +228,7 @@ def _place_front_end_and_insulators(
                 z_pos["weldment"],
             ],
             weldment,
-            f"{weldment.name}_{i}",
+            f"hpge_support_copper_weldment_top_{det_unit.name}_{i}",
             b.mother_lv,
             b.registry,
         )
@@ -263,7 +240,7 @@ def _place_front_end_and_insulators(
                 z_pos["insulator"],
             ],
             insulator,
-            f"{insulator.name}_{i}",
+            f"ultem_insulator_du_holder_{det_unit.name}_{i}",
             b.mother_lv,
             b.registry,
         )
@@ -457,11 +434,7 @@ def _place_hpge_string(
     )
 
     copper_rod_r = string_meta.rod_radius_in_mm
-    copper_rod_name = f"hpge_support_copper_rod_string_{string_id}"
-    # the rod has a radius of 1.5 mm, but this would overlap with the coarse model of the PPC top PEN ring.
-    copper_rod = geant4.solid.Tubs(copper_rod_name, 0, 1.5, copper_rod_length, 0, 2 * math.pi, b.registry)
-    copper_rod = geant4.LogicalVolume(copper_rod, b.materials.metal_copper, copper_rod_name, b.registry)
-    copper_rod.pygeom_color_rgba = (0.72, 0.45, 0.2, 1)
+    copper_rod = _get_copper_rod(copper_rod_length, b)
     for i in range(3):
         copper_rod_th = np.deg2rad(-30 - i * 120)
         delta = copper_rod_r * string_rot_m @ np.array([np.cos(copper_rod_th), np.sin(copper_rod_th)])
@@ -469,7 +442,7 @@ def _place_hpge_string(
             [0, 0, 0],
             [x_pos + delta[0], y_pos + delta[1], z_pos_dict["copper_rod_upper_end"] - copper_rod_length / 2],
             copper_rod,
-            f"{copper_rod_name}_{i}",
+            f"hpge_support_copper_rod_string_{string_id}_{i}",
             b.mother_lv,
             b.registry,
         )
@@ -548,301 +521,358 @@ def _add_pen_surfaces(
 
 
 def _get_hv_cable(
-    name: str,
     cable_thickness: float,
-    clamp_thickness: float,
     cable_length: float,
-    materials: materials.OpticalMaterialRegistry,
-    mother_pv: geant4.LogicalVolume,
-    reg: geant4.Registry,
-):
+    b: core.InstrumentationData,
+) -> geant4.LogicalVolume:
+    """Get the HV cable of the requested length, creating it on first use."""
+    cable_name = f"cable_hv_{cable_length:.2f}"
+    if cable_name in b.registry.logicalVolumeDict:
+        return b.registry.logicalVolumeDict[cable_name]
+
     safety_margin = 1  # mm
     cable_length -= safety_margin
 
     hv_cable_under_clamp = geant4.solid.Box(
-        "hv_cable_under_clamp_" + name,
+        f"{cable_name}_under_clamp",
         8,
         13,
         cable_thickness,
-        reg,
+        b.registry,
         "mm",
     )
     hv_cable_clamp_to_curve = geant4.solid.Box(
-        "hv_cable_clamp_to_curve_" + name,
+        f"{cable_name}_clamp_to_curve",
         5.5,
         2,
         cable_thickness,
-        reg,
+        b.registry,
         "mm",
     )
 
     hv_cable_curve = geant4.solid.Tubs(
-        "hv_cable_curve_" + name, 3.08, 3.08 + cable_thickness, 2.0, 0, math.pi / 2.0, reg, "mm"
+        f"{cable_name}_curve", 3.08, 3.08 + cable_thickness, 2.0, 0, math.pi / 2.0, b.registry, "mm"
     )
 
     hv_cable_along_unit = geant4.solid.Box(
-        "hv_along_unit_" + name,
+        f"{cable_name}_along_unit",
         cable_thickness,
         2.0,
         cable_length,
-        reg,
+        b.registry,
         "mm",
     )
 
     hv_cable_part1 = geant4.solid.Union(
-        "hv_cable_part1_" + name,
+        f"{cable_name}_part1",
         hv_cable_under_clamp,
         hv_cable_clamp_to_curve,
         [[0, 0, 0], [8 / 2.0 + 5.5 / 2.0, 0, 0]],
-        reg,
+        b.registry,
     )
 
     hv_cable_part2 = geant4.solid.Union(
-        "hv_cable_part2_" + name,
+        f"{cable_name}_part2",
         hv_cable_part1,
         hv_cable_curve,
         [[-np.pi / 2, 0, 0], [8 / 2.0 + 5.5, 0, 3.08 + cable_thickness / 2.0]],
-        reg,
+        b.registry,
     )
 
     hv_cable = geant4.solid.Union(
-        "cable_hv_" + name,
+        cable_name,
         hv_cable_part2,
         hv_cable_along_unit,
         [[0, 0, 0], [8 / 2.0 + 5.5 + 3.08 + cable_thickness / 2.0, 0, 3.08 + cable_length / 2.0]],
-        reg,
-    )
-
-    hv_clamp = geant4.solid.Box(
-        "ultem_clamp_hv_" + name,
-        5,
-        13,
-        clamp_thickness,
-        reg,
-        "mm",
+        b.registry,
     )
 
     hv_cable_lv = geant4.LogicalVolume(
         hv_cable,
-        materials.metal_copper,
-        "cable_hv_" + name,
-        reg,
+        b.materials.metal_copper,
+        cable_name,
+        b.registry,
+    )
+    hv_cable_lv.pygeom_color_rgba = (0.72, 0.45, 0.2, 1)
+
+    return hv_cable_lv
+
+
+def _get_hv_clamp(clamp_thickness: float, b: core.InstrumentationData) -> geant4.LogicalVolume:
+    """Get the HV cable clamp, creating it on first use."""
+    clamp_name = "ultem_clamp_hv"
+    if clamp_name in b.registry.logicalVolumeDict:
+        return b.registry.logicalVolumeDict[clamp_name]
+
+    hv_clamp = geant4.solid.Box(
+        clamp_name,
+        5,
+        13,
+        clamp_thickness,
+        b.registry,
+        "mm",
     )
 
     hv_clamp_lv = geant4.LogicalVolume(
         hv_clamp,
-        materials.ultem,
-        "ultem_clamp_hv_" + name,
-        reg,
+        b.materials.ultem,
+        clamp_name,
+        b.registry,
     )
+    hv_clamp_lv.pygeom_color_rgba = (0.3, 0.3, 0.3, 1)
 
-    return hv_cable_lv, hv_clamp_lv
+    return hv_clamp_lv
 
 
-def _get_signal_cable_and_asic(
-    name: str,
+def _get_signal_cable(
     cable_thickness: float,
-    clamp_thickness: float,
     cable_length: float,
-    materials: materials.OpticalMaterialRegistry,
-    mother_pv: geant4.LogicalVolume,
-    reg: geant4.Registry,
-):
+    b: core.InstrumentationData,
+) -> geant4.LogicalVolume:
+    """Get the signal cable of the requested length, creating it on first use."""
+    cable_name = f"cable_signal_{cable_length:.2f}"
+    if cable_name in b.registry.logicalVolumeDict:
+        return b.registry.logicalVolumeDict[cable_name]
+
     safety_margin = 1  # mm
     cable_length -= safety_margin
 
     signal_cable_under_clamp = geant4.solid.Box(
-        "signal_cable_under_clamp_" + name,
+        f"{cable_name}_under_clamp",
         16,
         13,
         cable_thickness,
-        reg,
+        b.registry,
         "mm",
     )
     signal_cable_clamp_to_curve = geant4.solid.Box(
-        "signal_cable_clamp_to_curve_" + name,
+        f"{cable_name}_clamp_to_curve",
         23.25,
         2,
         cable_thickness,
-        reg,
+        b.registry,
         "mm",
     )
     signal_cable_curve = geant4.solid.Tubs(
-        "signal_cable_curve_" + name, 3.08, 3.08 + cable_thickness, 2.0, 0, math.pi / 2.0, reg, "mm"
+        f"{cable_name}_curve", 3.08, 3.08 + cable_thickness, 2.0, 0, math.pi / 2.0, b.registry, "mm"
     )
     signal_cable_along_unit = geant4.solid.Box(
-        "signal_along_unit_" + name,
+        f"{cable_name}_along_unit",
         cable_thickness,
         2.0,
         cable_length,
-        reg,
+        b.registry,
         "mm",
     )
     signal_cable_part1 = geant4.solid.Union(
-        "signal_cable_part1_" + name,
+        f"{cable_name}_part1",
         signal_cable_under_clamp,
         signal_cable_clamp_to_curve,
         [[0, 0, 0], [16 / 2.0 + 23.25 / 2.0, 0, 0]],
-        reg,
+        b.registry,
     )
     signal_cable_part2 = geant4.solid.Union(
-        "signal_cable_part2_" + name,
+        f"{cable_name}_part2",
         signal_cable_part1,
         signal_cable_curve,
         [[np.pi / 2, 0, 0], [16 / 2.0 + 23.25, 0, -3.08 - cable_thickness / 2.0]],
-        reg,
+        b.registry,
     )
     signal_cable = geant4.solid.Union(
-        "cable_signal_" + name,
+        cable_name,
         signal_cable_part2,
         signal_cable_along_unit,
         [[0, 0, 0], [16 / 2.0 + 23.25 + 3.08 + cable_thickness / 2.0, 0, -3.08 - cable_length / 2.0]],
-        reg,
-    )
-
-    signal_clamp_part1 = geant4.solid.Box(
-        "signal_clamp_part1_" + name,
-        5,
-        13,
-        clamp_thickness,
-        reg,
-        "mm",
-    )
-    signal_clamp_part2 = geant4.solid.Box(
-        "signal_clamp_part2_" + name,
-        9,
-        2.5,
-        clamp_thickness,
-        reg,
-        "mm",
-    )
-    signal_clamp_part3 = geant4.solid.Union(
-        "signal_clamp_part3_" + name,
-        signal_clamp_part1,
-        signal_clamp_part2,
-        [[0, 0, 0], [5 / 2.0 + 9 / 2.0, 13 / 2.0 - 2.5 / 2.0, 0]],
-        reg,
-    )
-    signal_clamp = geant4.solid.Union(
-        "ultem_clamp_signal_" + name,
-        signal_clamp_part3,
-        signal_clamp_part2,
-        [[0, 0, 0], [5 / 2.0 + 9 / 2.0, -13 / 2.0 + 2.5 / 2.0, 0]],
-        reg,
-    )
-
-    signal_asic = geant4.solid.Box(
-        "signal_asic_" + name,
-        1,
-        1,
-        0.5,
-        reg,
-        "mm",
+        b.registry,
     )
 
     signal_cable_lv = geant4.LogicalVolume(
         signal_cable,
-        materials.metal_copper,
-        "cable_signal_" + name,
-        reg,
+        b.materials.metal_copper,
+        cable_name,
+        b.registry,
+    )
+    signal_cable_lv.pygeom_color_rgba = (0.72, 0.45, 0.2, 1)
+
+    return signal_cable_lv
+
+
+def _get_signal_clamp(clamp_thickness: float, b: core.InstrumentationData) -> geant4.LogicalVolume:
+    """Get the signal cable clamp, creating it on first use."""
+    clamp_name = "ultem_clamp_signal"
+    if clamp_name in b.registry.logicalVolumeDict:
+        return b.registry.logicalVolumeDict[clamp_name]
+
+    signal_clamp_part1 = geant4.solid.Box(
+        f"{clamp_name}_part1",
+        5,
+        13,
+        clamp_thickness,
+        b.registry,
+        "mm",
+    )
+    signal_clamp_part2 = geant4.solid.Box(
+        f"{clamp_name}_part2",
+        9,
+        2.5,
+        clamp_thickness,
+        b.registry,
+        "mm",
+    )
+    signal_clamp_part3 = geant4.solid.Union(
+        f"{clamp_name}_part3",
+        signal_clamp_part1,
+        signal_clamp_part2,
+        [[0, 0, 0], [5 / 2.0 + 9 / 2.0, 13 / 2.0 - 2.5 / 2.0, 0]],
+        b.registry,
+    )
+    signal_clamp = geant4.solid.Union(
+        clamp_name,
+        signal_clamp_part3,
+        signal_clamp_part2,
+        [[0, 0, 0], [5 / 2.0 + 9 / 2.0, -13 / 2.0 + 2.5 / 2.0, 0]],
+        b.registry,
     )
 
     signal_clamp_lv = geant4.LogicalVolume(
         signal_clamp,
-        materials.ultem,
-        "ultem_clamp_signal_" + name,
-        reg,
+        b.materials.ultem,
+        clamp_name,
+        b.registry,
+    )
+    signal_clamp_lv.pygeom_color_rgba = (0.3, 0.3, 0.3, 1)
+
+    return signal_clamp_lv
+
+
+def _get_signal_asic(b: core.InstrumentationData) -> geant4.LogicalVolume:
+    """Get the front-end ASIC die, creating it on first use."""
+    asic_name = "signal_asic"
+    if asic_name in b.registry.logicalVolumeDict:
+        return b.registry.logicalVolumeDict[asic_name]
+
+    signal_asic = geant4.solid.Box(
+        asic_name,
+        1,
+        1,
+        0.5,
+        b.registry,
+        "mm",
     )
 
     signal_asic_lv = geant4.LogicalVolume(
         signal_asic,
-        materials.silica,
-        "signal_asic_" + name,
-        reg,
+        b.materials.silica,
+        asic_name,
+        b.registry,
     )
+    signal_asic_lv.pygeom_color_rgba = (0.73, 0.33, 0.4, 1)
 
-    return signal_cable_lv, signal_clamp_lv, signal_asic_lv
+    return signal_asic_lv
 
 
-def _get_weldment_and_insulator(
-    det_unit: HPGeDetUnit,
+def _get_weldment(
     weldment_top_flap_thickness: float,
-    insulator_du_holder_flap_thickness: float,
-    insulator_top_length: float,
-    materials: materials.OpticalMaterialRegistry,
-    reg: geant4.Registry,
-):
+    b: core.InstrumentationData,
+) -> geant4.LogicalVolume:
+    """Get the copper weldment holding a detector unit to the support rods."""
+    weldment_name = "hpge_support_copper_weldment_top"
+    if weldment_name in b.registry.logicalVolumeDict:
+        return b.registry.logicalVolumeDict[weldment_name]
+
     safety_margin = 0.1
     weldment_top_flap = geant4.solid.Box(
-        "hpge_support_copper_weldment_top_flap_" + det_unit.name,
+        f"{weldment_name}_flap",
         20.8,
         5,
         weldment_top_flap_thickness,
-        reg,
+        b.registry,
         "mm",
     )
 
     weldment_top_clamp = geant4.solid.Box(
-        "hpge_support_copper_weldment_top_clamp_" + det_unit.name,
+        f"{weldment_name}_clamp",
         7.8,
         5,
         2.2,
-        reg,
+        b.registry,
         "mm",
     )
 
     # Union the flap and clamp
     weldment_top_without_hole = geant4.solid.Union(
-        "hpge_support_copper_weldment_top_without_hole_" + det_unit.name,
+        f"{weldment_name}_without_hole",
         weldment_top_flap,
         weldment_top_clamp,
         [[0, 0, 0], [20.8 / 2.0 - 7.8 / 2.0, 0, -2.2 / 2.0 - weldment_top_flap_thickness / 2.0]],
-        reg,
+        b.registry,
     )
 
     weldment_top_carving_hole = geant4.solid.Tubs(
-        "hpge_support_copper_weldment_top_carving_hole_" + det_unit.name,
+        f"{weldment_name}_carving_hole",
         0,
         1.5 + safety_margin,
         2 * (weldment_top_flap_thickness + 2.2),
         0,
         math.pi * 2,
-        reg,
+        b.registry,
         "mm",
     )
 
     # Perform subtraction only once
     weldment_top = geant4.solid.Subtraction(
-        "hpge_support_copper_weldment_top_" + det_unit.name,
+        weldment_name,
         weldment_top_without_hole,
         weldment_top_carving_hole,
         [[0, 0, 0], [5.60, 0, 0]],  # Adjust the position of the hole as needed
-        reg,
+        b.registry,
     )
 
+    weldment_top_lv = geant4.LogicalVolume(
+        weldment_top,
+        b.materials.metal_copper,
+        weldment_name,
+        b.registry,
+    )
+    weldment_top_lv.pygeom_color_rgba = (0.6, 0.6, 0.6, 1)
+
+    return weldment_top_lv
+
+
+def _get_insulator(
+    insulator_du_holder_flap_thickness: float,
+    insulator_top_length: float,
+    b: core.InstrumentationData,
+) -> geant4.LogicalVolume:
+    """Get the Ultem insulator of the requested top length, creating it on first use."""
+    insulator_name = f"ultem_insulator_du_holder_{insulator_top_length:.2f}"
+    if insulator_name in b.registry.logicalVolumeDict:
+        return b.registry.logicalVolumeDict[insulator_name]
+
+    safety_margin = 0.1
     insulator_du_holder_flap = geant4.solid.Box(
-        "ultem_insulator_du_holder_flap_" + det_unit.name,
+        f"{insulator_name}_flap",
         16.5,
         7,
         insulator_du_holder_flap_thickness,
-        reg,
+        b.registry,
         "mm",
     )
 
     safety_margin_touching_detector = 0.25
 
     insulator_du_holder_clamp = geant4.solid.Box(
-        "ultem_insulator_du_holder_clamp_" + det_unit.name,
+        f"{insulator_name}_clamp",
         insulator_top_length - safety_margin_touching_detector,
         7,
         5.5 - insulator_du_holder_flap_thickness,
-        reg,
+        b.registry,
         "mm",
     )
 
     # Union the flap and clamp
     insulator_du_holder_without_hole = geant4.solid.Union(
-        "ultem_insulator_du_holder_without_hole_ " + det_unit.name,
+        f"{insulator_name}_without_hole",
         insulator_du_holder_flap,
         insulator_du_holder_clamp,
         [
@@ -853,41 +883,49 @@ def _get_weldment_and_insulator(
                 (5.5 - insulator_du_holder_flap_thickness) / 2.0 + insulator_du_holder_flap_thickness / 2.0,
             ],
         ],
-        reg,
+        b.registry,
     )
 
     insulator_du_holder_carving_hole = geant4.solid.Tubs(
-        "ultem_insulator_du_holder_carving_hole_" + det_unit.name,
+        f"{insulator_name}_carving_hole",
         0,
         1.5 + safety_margin,
         3 * 5.5,
         0,
         math.pi * 2,
-        reg,
+        b.registry,
         "mm",
     )
 
     # Perform subtraction only once
     insulator_du_holder = geant4.solid.Subtraction(
-        "ultem_insulator_du_holder_" + det_unit.name,
+        insulator_name,
         insulator_du_holder_without_hole,
         insulator_du_holder_carving_hole,
         [[0, 0, 0], [16.5 / 2.0 - 1.5, 0, 0]],  # Adjust the position of the hole as needed
-        reg,
-    )
-
-    weldment_top_lv = geant4.LogicalVolume(
-        weldment_top,
-        materials.metal_copper,
-        "hpge_support_copper_weldment_top_" + det_unit.name,
-        reg,
+        b.registry,
     )
 
     insulator_du_holder_lv = geant4.LogicalVolume(
         insulator_du_holder,
-        materials.ultem,
-        "ultem_insulator_du_holder_" + det_unit.name,
-        reg,
+        b.materials.ultem,
+        insulator_name,
+        b.registry,
     )
+    insulator_du_holder_lv.pygeom_color_rgba = (0.6, 0.6, 0.6, 1)
 
-    return weldment_top_lv, insulator_du_holder_lv
+    return insulator_du_holder_lv
+
+
+def _get_copper_rod(copper_rod_length: float, b: core.InstrumentationData) -> geant4.LogicalVolume:
+    """Get a string support rod of the requested length, creating it on first use."""
+    rod_name = f"hpge_support_copper_rod_{copper_rod_length:.2f}"
+    if rod_name in b.registry.logicalVolumeDict:
+        return b.registry.logicalVolumeDict[rod_name]
+
+    # the rod has a radius of 1.5 mm, but this would overlap with the coarse model of the PPC top PEN ring.
+    copper_rod = geant4.solid.Tubs(rod_name, 0, 1.5, copper_rod_length, 0, 2 * math.pi, b.registry)
+    copper_rod_lv = geant4.LogicalVolume(copper_rod, b.materials.metal_copper, rod_name, b.registry)
+    copper_rod_lv.pygeom_color_rgba = (0.72, 0.45, 0.2, 1)
+
+    return copper_rod_lv

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,6 +22,40 @@ def test_construct(tmp_path):
     core.construct()
 
 
+def test_volume_caching():
+    """Geometrically identical parts must share a single logical volume.
+
+    Each of these parts is identical across all detector units, so it must be built once and
+    placed many times. This guards against a regression where a logical volume name embeds a
+    per-detector or per-string identifier, which rebuilds the entire solid tree per placement.
+    """
+    from pygeoml1000 import core
+
+    registry = core.construct()
+
+    # name stem -> expected number of placements
+    expected_placements = {
+        "cable_hv": 336,
+        "cable_signal": 336,
+        "ultem_clamp_hv": 336,
+        "ultem_clamp_signal": 336,
+        "signal_asic": 336,
+        "hpge_support_copper_weldment_top": 1008,
+        "ultem_insulator_du_holder": 1008,
+        "hpge_support_copper_rod": 126,
+    }
+
+    for stem, n_expected in expected_placements.items():
+        lvs = [name for name in registry.logicalVolumeDict if name.startswith(stem)]
+        assert len(lvs) == 1, f"{stem}: expected exactly one cached logical volume, got {lvs}"
+
+        pvs = [name for name in registry.physicalVolumeDict if name.startswith(stem)]
+        assert len(pvs) == n_expected, f"{stem}: expected {n_expected} placements, got {len(pvs)}"
+
+    # a coarse guard against per-instance logical volumes creeping back in elsewhere.
+    assert len(registry.logicalVolumeDict) < 600
+
+
 def test_read_back(tmp_path):
     from pygeoml1000 import core
 


### PR DESCRIPTION
Similar to the implementation in the l200 geometry definition, logical volumes have previously been generated per detector unit but are identical each time, and are now cached and stored as duplicate physical volumes. This reduces overhead in the gdml generation and file size.