### PR TITLE
feat: add parts manifest generation and CLI option for YAML output

### DIFF
--- a/docs/source/cli_usage.md
+++ b/docs/source/cli_usage.md
@@ -175,6 +175,63 @@ legend-pygeom-l1000 l1000.gdml --check-overlaps
 Overlap checking can be slow for complex geometries and may not catch all overlap issues. It's recommended to verify geometries with Geant4 as well. Refer to [l200:geom-dev](https://legend-pygeom-l200.readthedocs.io/en/stable/geom-dev.html) for details.
 ```
 
+#### Parts Manifest
+
+Write a YAML manifest of every part in the geometry, with its material, its
+number of placements and its total mass:
+
+```console
+legend-pygeom-l1000 --write-manifest parts.yaml
+```
+
+No GDML file has to be produced. The manifest is meant to be cross-checked
+against the experiment's bill of materials, and to provide the mass of each
+material present in the simulation for background studies.
+
+```yaml
+metadata:
+  package_version: 0.4
+  detail_level: radiogenic
+  assemblies: null
+  mesh_slices: 100
+  n_logical_volumes: 370
+  n_physical_volumes: 17196
+  units:
+    volume: cm**3
+    mass: g
+    density: g/cm**3
+totals:
+  mass: 373458272.2
+  by_material:
+    LiquidArgon: 280951383.1
+    metal_steel: 84623861.8
+    # ...
+parts:
+  - name: cable_hv_140.10
+    material: metal_copper
+    density: 8.96
+    solid: Union
+    placements: 336
+    unit_volume: 0.4193
+    total_volume: 140.9
+    total_mass: 1262.1
+  # ...
+```
+
+There is one entry per logical volume, sorted by descending total mass.
+`placements` is the number of times that volume occurs in the whole geometry,
+counted through the volume tree.
+
+The manifest only describes what is actually in the geometry, so it follows
+`--detail` and `--assemblies`. Parts that are omitted are absent from it rather
+than listed with zero mass.
+
+```{note}
+Volumes are derived from the meshes computed by pyg4ometry, so the masses are
+approximations. `--write-manifest` therefore builds the geometry with a fine
+mesh (100 slices).
+```
+
 ### Optical Properties
 
 #### Custom Optical Properties Plugin

--- a/src/pygeoml1000/cli.py
+++ b/src/pygeoml1000/cli.py
@@ -11,7 +11,7 @@ from pyg4ometry import config as meshconfig
 from pygeomoptics.store import load_user_material_code
 from pygeomtools import detectors, visualization, write_pygeom
 
-from . import _version, config_compilation, core
+from . import _version, config_compilation, core, manifest
 
 log = logging.getLogger(__name__)
 
@@ -78,6 +78,11 @@ def dump_gdml_cli() -> None:
         help="""Select the assemblies to generate in the output. If specified, changes all unspecified assemblies to 'omit'.""",
     )
     geom_opts.add_argument(
+        "--write-manifest",
+        action="store",
+        help="""Filename to write a YAML parts manifest to, listing the material, the number of placements and the total mass of each part in the geometry""",
+    )
+    geom_opts.add_argument(
         "--detail",
         action="store",
         default="radiogenic",
@@ -125,6 +130,7 @@ def dump_gdml_cli() -> None:
         and args.filename is None
         and not args.generate_compiled_config
         and not args.copy_raw_configs_into_cwd_folder
+        and not args.write_manifest
     ):
         parser.error("no output file, no visualization, and no metadata generation specified")
     if (args.vis_macro_file or args.det_macro_file) and args.filename is None:
@@ -167,6 +173,7 @@ def dump_gdml_cli() -> None:
         (args.generate_compiled_config or args.copy_raw_configs_into_cwd_folder)
         and args.filename is None
         and not args.visualize
+        and not args.write_manifest
     ):
         return
 
@@ -174,7 +181,9 @@ def dump_gdml_cli() -> None:
     if isinstance(args.visualize, str):
         vis_scene = dbetto.utils.load_dict(args.visualize)
 
-    if vis_scene.get("fine_mesh", False) or args.check_overlaps:
+    # the manifest masses are derived from the meshes, and the default discretisation of curved
+    # solids (16 slices) underestimates their volume by ~2.5%.
+    if vis_scene.get("fine_mesh", False) or args.check_overlaps or args.write_manifest:
         meshconfig.setGlobalMeshSliceAndStack(100)
 
     # load custom module to change material properties.
@@ -187,6 +196,15 @@ def dump_gdml_cli() -> None:
         config=config,
         input_config_folder=args.input_raw_config_folder,
     )
+
+    if args.write_manifest:
+        log.info("writing parts manifest to %s", args.write_manifest)
+        manifest.write_manifest(
+            registry,
+            args.write_manifest,
+            detail_level=args.detail,
+            assemblies=args.assemblies.split(",") if args.assemblies else None,
+        )
 
     if args.check_overlaps:
         msg = "checking for overlaps"

--- a/src/pygeoml1000/manifest.py
+++ b/src/pygeoml1000/manifest.py
@@ -1,0 +1,167 @@
+"""Generate a parts manifest: the mass of every part actually present in the geometry.
+
+The manifest lists one entry per logical volume, with its material, its number of placements and
+the resulting total mass. This can be used as a cross-checked against the experiment estimated material count.
+"""
+
+from __future__ import annotations
+
+import collections
+import logging
+from pathlib import Path
+from typing import Any
+
+import pint
+import yaml
+from pyg4ometry import config as meshconfig
+from pyg4ometry import geant4
+
+from . import _version
+
+log = logging.getLogger(__name__)
+
+u = pint.get_application_registry()
+
+#: units of the numerical quantities in the manifest.
+UNITS = {"volume": "cm**3", "mass": "g", "density": "g/cm**3"}
+
+#: unit of the volumes returned by :meth:`pyg4ometry.pycsg.core.CSG.volume`
+MESH_VOLUME_UNIT = "mm**3"
+
+#: unit of :attr:`pyg4ometry.geant4.Material.density`
+DENSITY_UNIT = "g/cm**3"
+
+
+def _count_placements(world_lv: geant4.LogicalVolume) -> collections.Counter:
+    """Count how often each logical volume is placed in the tree below ``world_lv``.
+
+    The multiplicity has to be propagated down the tree: a logical volume placed once inside a
+    mother that is itself placed 12096 times is present 12096 times. Counting only the physical
+    volumes that directly reference a logical volume is off by that factor.
+    """
+    memo: dict[str, collections.Counter] = {}
+
+    def walk(lv: geant4.LogicalVolume) -> collections.Counter:
+        if lv.name in memo:
+            return memo[lv.name]
+
+        total = collections.Counter({lv.name: 1})
+        for pv in lv.daughterVolumes:
+            total += walk(pv.logicalVolume)
+
+        memo[lv.name] = total
+        return total
+
+    return walk(world_lv)
+
+
+def _own_volume(lv: geant4.LogicalVolume, mesh_volumes: dict[str, float]) -> float:
+    """Get the volume in :data:`MESH_VOLUME_UNIT` occupied by the material of ``lv`` itself, i.e.
+    the volume of its solid minus the volumes of its daughters.
+
+    This is :func:`pygeomtools.geometry.get_approximate_volume`, but caching the mesh volumes in
+    ``mesh_volumes``.
+    """
+
+    def mesh_volume(lv: geant4.LogicalVolume) -> float:
+        if lv.name not in mesh_volumes:
+            mesh_volumes[lv.name] = lv.solid.mesh().volume()
+        return mesh_volumes[lv.name]
+
+    volume = mesh_volume(lv)
+    for pv in lv.daughterVolumes:
+        volume -= mesh_volume(pv.logicalVolume)
+
+    return volume
+
+
+def generate_manifest(
+    registry: geant4.Registry,
+    detail_level: str | None = None,
+    assemblies: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build the parts manifest for an already-constructed geometry.
+
+    The returned document has three sections: ``metadata`` describing how the geometry was built,
+    ``totals`` with the total mass per material, and ``parts`` with one entry per logical volume,
+    sorted by descending mass.
+
+    Parameters
+    ----------
+    registry
+        the registry returned by :func:`pygeoml1000.core.construct`.
+    detail_level
+        the detail level the geometry was constructed with, recorded in the manifest metadata.
+    assemblies
+        the assemblies the geometry was constructed with, recorded in the manifest metadata.
+
+    """
+    world_lv = registry.worldVolume
+    placements = _count_placements(world_lv)
+
+    mesh_volumes: dict[str, float] = {}
+    parts = []
+    mass_by_material: collections.Counter = collections.Counter()
+
+    for name, n_placements in placements.items():
+        if name == world_lv.name:
+            continue  # the world is not a part.
+
+        lv = registry.logicalVolumeDict[name]
+        unit_volume = (_own_volume(lv, mesh_volumes) * u(MESH_VOLUME_UNIT)).to(UNITS["volume"])
+        total_volume = unit_volume * n_placements
+        density = float(getattr(lv.material, "density", 0.0) or 0.0) * u(DENSITY_UNIT)
+        total_mass = (total_volume * density).to(UNITS["mass"])
+
+        mass_by_material[lv.material.name] += total_mass.m
+        parts.append(
+            {
+                "name": name,
+                "material": lv.material.name,
+                "density": density.m,
+                "solid": type(lv.solid).__name__,
+                "placements": n_placements,
+                "unit_volume": unit_volume.m,
+                "total_volume": total_volume.m,
+                "total_mass": total_mass.m,
+            }
+        )
+
+    parts.sort(key=lambda part: (-part["total_mass"], part["name"]))
+
+    return {
+        "metadata": {
+            "package_version": _version.__version__,
+            "detail_level": detail_level,
+            "assemblies": assemblies,
+            "mesh_slices": meshconfig.SolidDefaults.Tubs.nslice,
+            "n_logical_volumes": len(registry.logicalVolumeDict),
+            "n_physical_volumes": len(registry.physicalVolumeDict),
+            "units": dict(UNITS),
+        },
+        "totals": {
+            "mass": sum(mass_by_material.values()),
+            "by_material": dict(mass_by_material.most_common()),
+        },
+        "parts": parts,
+    }
+
+
+def write_manifest(
+    registry: geant4.Registry,
+    filename: str | Path,
+    detail_level: str | None = None,
+    assemblies: list[str] | None = None,
+) -> None:
+    """Write the parts manifest of ``registry`` to ``filename`` as YAML."""
+    manifest = generate_manifest(registry, detail_level=detail_level, assemblies=assemblies)
+
+    with Path(filename).open("w") as f:
+        yaml.safe_dump(manifest, f, sort_keys=False, default_flow_style=False)
+
+    log.info(
+        "wrote parts manifest of %d parts (%.1f kg total) to %s",
+        len(manifest["parts"]),
+        manifest["totals"]["mass"] / 1000,
+        filename,
+    )

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,89 @@
+# ruff: noqa: PLC0415
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+
+@pytest.fixture(scope="module")
+def manifest():
+    from pygeoml1000 import core, manifest
+
+    return manifest.generate_manifest(core.construct(), detail_level="radiogenic")
+
+
+def _part(manifest, name):
+    parts = [part for part in manifest["parts"] if part["name"] == name]
+    assert len(parts) == 1, f"{name}: expected exactly one entry, got {len(parts)}"
+    return parts[0]
+
+
+def test_pyg4ometry_units():
+    """The manifest assumes mesh volumes in mm^3 and densities in g/cm3.
+
+    Neither is parametrised in pyg4ometry: a solid is converted to mm when it is meshed, whatever
+    ``lunit`` it was declared with, and a density is stored as given and written to GDML without a
+    unit attribute. If either ever changed, every mass in the manifest would silently be off by a
+    constant factor, so pin them here.
+    """
+    from pyg4ometry import geant4
+
+    from pygeoml1000 import manifest
+
+    registry = geant4.Registry()
+    assert geant4.solid.Box("in_mm", 10, 10, 10, registry, "mm").mesh().volume() == 1e3
+    assert geant4.solid.Box("in_m", 1, 1, 1, registry, "m").mesh().volume() == 1e9
+    assert manifest.MESH_VOLUME_UNIT == "mm**3"
+
+    material = geant4.Material(name="copperish", density=8.96, number_of_components=1, registry=registry)
+    assert material.density == 8.96
+    assert manifest.DENSITY_UNIT == "g/cm**3"
+
+
+def test_placement_multiplicity(manifest):
+    """The placement count must be propagated down the volume tree."""
+    core_fiber = _part(manifest, "fiber_core_l1349_bNone")
+    assert core_fiber["placements"] == 12096
+    assert core_fiber["total_mass"] > 10_000  # g
+
+    # cross-check against test_volume_caching, which asserts the same numbers on the registry.
+    assert _part(manifest, "cable_hv_140.10")["placements"] == 336
+    assert _part(manifest, "hpge_support_copper_weldment_top")["placements"] == 1008
+
+
+def test_totals_are_consistent(manifest):
+    total = sum(part["total_mass"] for part in manifest["parts"])
+    assert total == pytest.approx(manifest["totals"]["mass"])
+    assert sum(manifest["totals"]["by_material"].values()) == pytest.approx(total)
+
+
+def test_parts_are_sane(manifest):
+    from pygeoml1000 import core
+
+    registry = core.construct()
+    # the world volume is not a part, everything else in the registry is.
+    assert len(manifest["parts"]) == len(registry.logicalVolumeDict) - 1
+
+    for part in manifest["parts"]:
+        assert part["unit_volume"] > 0, f"{part['name']} has a non-positive volume"
+        assert part["placements"] >= 1
+        assert part["material"] in registry.materialDict
+        assert part["total_volume"] == pytest.approx(part["unit_volume"] * part["placements"])
+
+    masses = [part["total_mass"] for part in manifest["parts"]]
+    assert masses == sorted(masses, reverse=True), "parts are not sorted by descending mass"
+
+
+def test_write_manifest(tmp_path):
+    from pygeoml1000 import core, manifest
+
+    manifest_file = tmp_path / "parts.yaml"
+    manifest.write_manifest(core.construct(), manifest_file, detail_level="radiogenic")
+
+    with manifest_file.open() as f:
+        read_back = yaml.safe_load(f)
+
+    assert read_back["metadata"]["detail_level"] == "radiogenic"
+    assert read_back["metadata"]["n_logical_volumes"] == len(read_back["parts"]) + 1
+    assert read_back["totals"]["mass"] > 0


### PR DESCRIPTION
This PR implements a small manifest generator to count the number of individual parts implemented as well as their combined mass. This is of interest to compare the current simulation implementation with the planned number of parts and their mass, as detailed in the bill of materials for LEGEND-1000.