### PR TITLE
Refactor config input to allign with pygeoml200 and preparation for use in legend-simflow

### DIFF
--- a/docs/generate_docs_images.py
+++ b/docs/generate_docs_images.py
@@ -13,7 +13,6 @@ Usage::
 from __future__ import annotations
 
 import argparse
-import copy
 import logging
 import math
 import re
@@ -25,7 +24,7 @@ from pyg4ometry import geant4 as g4
 from pyg4ometry.transformation import tbxyz2matrix
 from pygeomtools import viewer, write_pygeom
 
-from pygeoml1000 import config_compilation, core
+from pygeoml1000 import config, core
 
 log = logging.getLogger("generate_docs_images")
 
@@ -182,7 +181,7 @@ IMAGES = {
 
 
 def _subset_metadata(
-    strings: set[int] | None, positions: set[int] | None, input_config_folder: str = ""
+    strings: set[int] | None, positions: set[int] | None, raw_config: dict | str = ""
 ) -> dict:
     """Build a config restricted to the given strings (and detector positions).
 
@@ -193,11 +192,9 @@ def _subset_metadata(
     if strings is None:
         return {}
 
-    channelmap, special_metadata = config_compilation.generate_dummy_metadata(
-        input_config_folder=input_config_folder
-    )
-    channelmap = copy.deepcopy(channelmap)
-    special_metadata = copy.deepcopy(special_metadata)
+    resolved = config.resolve_config({"raw_config": raw_config} if raw_config else {})
+    channelmap = resolved["channelmap"]
+    special_metadata = resolved["special_metadata"]
 
     def _keep_ged(ch: dict) -> bool:
         loc = ch["location"]
@@ -330,12 +327,10 @@ def export_image(name: str, spec: dict) -> None:
     """Build the geometry for one view and render it to ``docs/source/images``."""
     log.info("building geometry for %s", name)
 
-    config = _subset_metadata(spec.get("strings"), spec.get("positions"))
-    registry = core.construct(
-        assemblies=list(spec["assemblies"]),
-        detail_level=spec.get("detail", "radiogenic"),
-        config=config,
-    )
+    geom_config = _subset_metadata(spec.get("strings"), spec.get("positions"))
+    geom_config["assemblies"] = list(spec["assemblies"])
+    geom_config["detail"] = spec.get("detail", config.DEFAULT_DETAIL)
+    registry = core.construct(geom_config)
     log.info("%s: %d physical volumes", name, len(registry.physicalVolumeDict))
 
     write_pygeom(registry, None)

--- a/docs/source/cli_usage.md
+++ b/docs/source/cli_usage.md
@@ -127,13 +127,21 @@ legend-pygeom-l1000 l1000_cosmogenic.gdml --detail cosmogenic
 Select specific assemblies to include in the geometry:
 
 ```console
-legend-pygeom-l1000 --assemblies "watertank,cryo,hpge_strings" l1000.gdml
+legend-pygeom-l1000 --assemblies "watertank,cryostat,HPGe_dets" l1000.gdml
 ```
 
-When `--assemblies` is specified, all unspecified assemblies are omitted from
-the geometry. Available assemblies include:
+When `--assemblies` is specified as a list of plain names, all unspecified
+assemblies are omitted from the geometry. Entries can instead be prefixed by `+`
+or `-` to modify the set of assemblies enabled by the detail level (either all
+entries carry an operator, or none do):
 
-- `caver`: Cavern and surrounding rock
+```console
+legend-pygeom-l1000 --assemblies "+watertank,-fiber_curtain" l1000.gdml
+```
+
+Available assemblies include:
+
+- `cavern`: Cavern and surrounding rock
 - `labs`: Experimental laboratory halls (not implemented yet)
 - `watertank`: Water tank and surrounding infrastructure
 - `watertank_instrumentation`: PMTs in the water tank
@@ -147,19 +155,36 @@ the geometry. Available assemblies include:
 - `PEN_plates`: PEN baseplates
 - `HPGe_dets`: HPGe detectors
 
-For more details see `src/pygeoml1000/configs/config.json`.
+The cryostat must be included whenever `HPGe_dets` or `fiber_curtain` are. For
+more details see the `detail.yaml` section of {doc}`runtime-cfg`.
 
 #### Custom Configuration
 
-Use a custom configuration file to override default geometry parameters:
+Use a configuration file to describe the geometry:
 
 ```console
-legend-pygeom-l1000 l1000.gdml --config custom_config.json
+legend-pygeom-l1000 l1000.gdml --config geom-config.yaml
 ```
 
-The configuration file is a JSON file that can specify various geometry
-parameters, material choices, and component dimensions. It is treated as a
-substitute for `src/pygeoml1000/configs/config.json`.
+Everything that defines the geometry can be set there, including the detail
+level, the assembly selection, overrides of the raw configuration, and a fully
+compiled `channelmap`/`special_metadata`. `--detail` and `--assemblies` override
+their config file counterparts. See {doc}`runtime-cfg` for the full reference.
+
+To write out the resolved configuration, i.e, the raw configuration compiled
+into an explicit `channelmap` and `special_metadata`, for archival or
+hand-editing:
+
+```console
+legend-pygeom-l1000 --config geom-config.yaml --write-config resolved.yaml l1000.gdml
+```
+
+To get a copy of the raw config files shipped with the package as a starting
+point for a custom configuration:
+
+```console
+legend-pygeom-l1000 --dump-raw-configs .
+```
 
 ### Quality Control
 
@@ -273,7 +298,7 @@ Use a custom configuration and check for overlaps:
 
 ```console
 legend-pygeom-l1000 \
-  --config my_config.json \
+  --config geom-config.yaml \
   --check-overlaps \
   --verbose
 ```
@@ -302,12 +327,13 @@ For final, production-ready geometries:
 
 1. Use `--detail radiogenic` for radiogenic detail
 2. Run with `--check-overlaps` to verify geometry integrity
-3. Use custom `--config` files to document specific geometry variations
+3. Use custom `--config` files to document specific geometry variations, and
+   `--write-config` to archive the exact geometry that was built
 
 ### Performance Considerations
 
-- Overlap checking is computationally expensive; use sparingly
+- Overlap checking is computationally expensive. Use sparingly
 - Fine mesh visualization (`"fine_mesh": true` in scene files) increases memory
   usage
-- Maximum verbosity (`--debug`) generates large log outputs; use only when
+- Maximum verbosity (`--debug`) generates large log outputs. Use only when
   troubleshooting

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -78,7 +78,7 @@ legend-pygeom-l1000 --visualize
 Generate with specific detail level:
 
 ```console
-legend-pygeom-l1000 l1000.gdml --detail comsogenic
+legend-pygeom-l1000 l1000.gdml --detail cosmogenic
 ```
 
 For detailed usage information, see the {doc}`cli_usage`.

--- a/docs/source/runtime-cfg.md
+++ b/docs/source/runtime-cfg.md
@@ -237,6 +237,7 @@ pulse-shape discrimination, but is not read by the geometry generation itself.
 ## Compilation
 
 The compilation step converts the raw config files into the two runtime objects
+
 - `special_metadata` and `channelmap` - via `config.py`.
 
 **`special_metadata`** contains the detailed spatial layout used for geometry

--- a/docs/source/runtime-cfg.md
+++ b/docs/source/runtime-cfg.md
@@ -1,33 +1,109 @@
 # Runtime configuration
 
-The details defining the geometry of the detector strings and water tank
-instrumentation can be specified at runtime using configuration files. This
-allows for flexible geometry generation without needing to modify the code
-directly.
+A geometry is fully described by a single config file, passed to the generator
+with `--config`:
 
-The _raw_ configuration files are located in `src/pygeoml1000/configs/`. These
-consist of high-level geometry parameters (e.g. number of detectors per string,
-PMT positions) that are used in the script execution to generate the
-`special_metadata` and `channelmap` objects. The former is a detailed spatial
-configuration of the geometry, while the latter defines the detector mapping and
-electronics configuration similar to the channelmap defined in the usual
-metadata. `legend-pygeom-l1000` uses these objects to place the geometry of the
-specified objects in the geometry. In addition, a _compiled_ version of these
-objects can be returned and again fed into the geometry generation. This system
-allows users to easily create different geometry variants by modifying first the
-raw config files for high-level changes, then by modifying the compiled config
-for more detailed changes.
+```console
+$ legend-pygeom-l1000 --config geom-config.yaml l1000.gdml
+```
 
-This section first discusses the configuration file format and structure, then
-the compilation process, and finally, best practices for using the configuration
-system effectively.
+The file is YAML or JSON, and is validated against a JSON schema shipped with
+the package (`src/pygeoml1000/configs/runtime_config_schema.yaml`), so a value
+of the wrong type is reported instead of silently ignored. Unknown keys are
+allowed through, so that a config carrying extra fields for the calling workflow
+still validates. Its key names are deliberately kept in sync with
+[legend-pygeom-l200](https://legend-pygeom-l200.readthedocs.io), so that the
+same geometry config layout works for both generators. This is what lets
+[legend-simflow](https://legend-simflow.readthedocs.io) drive either of them
+through one workflow rule.
+
+The geometry itself is built from two objects: `special_metadata`, a detailed
+spatial configuration, and `channelmap`, the detector mapping and electronics
+configuration (similar to the channelmap in the usual metadata). Those can be
+supplied in two ways, and the choice is made by which keys the config file
+contains, not by which command line flags are used:
+
+- as a **raw** configuration: high-level geometry parameters (number of
+  detectors per string, PMT positions, ...) that get _compiled_ into
+  `special_metadata` and `channelmap`. This is the default. `raw_config`
+  overrides individual raw values.
+- as a **compiled** configuration: `special_metadata` and `channelmap` given
+  directly, either inline or as paths to separate files. Then no compilation
+  happens at all.
+
+The typical workflow uses both: change the raw config for structural changes,
+write the result out with `--write-config`, and edit that for fine-grained
+adjustments.
+
+## Config file reference
+
+| key                  | type            | meaning                                                                              |
+| -------------------- | --------------- | ------------------------------------------------------------------------------------ |
+| `detail`             | string          | detail level preset, a key of `detail.yaml` (default: `radiogenic`)                  |
+| `assemblies`         | list or string  | assemblies to build, see [Selecting assemblies](#selecting-assemblies)               |
+| `raw_config`         | mapping or path | raw configuration overrides, see [Raw configuration files](#raw-configuration-files) |
+| `special_metadata`   | mapping or path | compiled spatial configuration, skips compiling it from the raw config               |
+| `channelmap`         | mapping or path | compiled channel map, skips compiling it from the raw config                         |
+| `sipm_use_pde_curve` | bool            | if false, use a flat SiPM photon detection efficiency instead of the PDE curve       |
+| `sipm_efficiencies`  | mapping         | per-channel scale factors for the SiPM detection efficiency                          |
+
+Every option that defines the geometry lives in this file. The command line only
+selects which artifacts to produce (`--write-manifest`, `--det-macro-file`, the
+output GDML, ...), with the exception of `--detail` and `--assemblies`, which
+override their config file counterparts.
+
+(selecting-assemblies)=
+
+### Selecting assemblies
+
+`assemblies` selects which parts of the setup are built. Given as plain names it
+is an absolute selection:
+
+```yaml
+assemblies: [cryostat, HPGe_dets, PEN_plates]
+```
+
+Alternatively, every entry can be prefixed by `+` or `-` to modify the set of
+assemblies that the chosen detail level enables (either all entries carry an
+operator, or none do):
+
+```yaml
+assemblies: [+watertank, -fiber_curtain]
+```
+
+Assemblies that are not selected are switched to `omit`. Selected assemblies
+that the detail level omits are built at the `simple` detail level. The cryostat
+must be included whenever `HPGe_dets` or `fiber_curtain` are.
+
+(raw-configuration-files)=
 
 ## Raw configuration files
 
 The raw configuration files are YAML files located in
 `src/pygeoml1000/configs/`. Each file controls a specific aspect of the
-geometry. A custom folder can be passed at runtime via
-`--input-raw-config-folder`.
+geometry.
+
+The `raw_config` key overrides them. It is deep-merged on top of the packaged
+files, so only the values that actually change have to be given:
+
+```yaml
+raw_config:
+  string:
+    units:
+      n: 10 # 10 detector units per string, everything else unchanged
+```
+
+It can also be the path to a folder of raw config files, which is again merged
+over the packaged ones. A file that is not in the folder simply keeps its
+packaged contents:
+
+```yaml
+raw_config: /path/to/my/configs
+```
+
+Use `--dump-raw-configs <dir>` to get a copy of the packaged files as a starting
+point. `raw_config` is ignored (with a warning) if both `channelmap` and
+`special_metadata` are given, since then nothing needs to be compiled.
 
 The `configs` folder in the source directory contains the following raw config
 files:
@@ -44,7 +120,7 @@ configs/
 └── string.yaml
 ```
 
-### `array.yaml` — String array layout
+### `array.yaml` - String array layout
 
 Defines the positions and orientations of the detector string array:
 
@@ -64,7 +140,7 @@ angle_in_deg: [0, 60, 120, 180, 240, 300]
   cluster. The total number of strings is
   `len(center.x_in_mm) × len(angle_in_deg)`.
 
-### `string.yaml` — Detector string properties
+### `string.yaml` - Detector string properties
 
 Defines the physical parameters of a single detector string:
 
@@ -85,7 +161,7 @@ n_sipm_modules_per_string: 3
   string center (in mm).
 - `n_sipm_modules_per_string`: number of SiPM fiber modules per string.
 
-### `hpge.yaml` — HPGe detector template
+### `hpge.yaml` - HPGe detector template
 
 Provides the template channelmap entry for all HPGe detectors. All detectors in
 the generated channelmap start from this template and have their `name`,
@@ -93,19 +169,19 @@ the generated channelmap start from this template and have their `name`,
 during compilation. The template includes full geometry, production, and
 characterization sub-fields following the standard LEGEND metadata format.
 
-### `sipm.yaml` — SiPM module template
+### `sipm.yaml` - SiPM module template
 
 Provides the template channelmap entry for SiPM fiber modules. During
 compilation, `name`, `location.barrel`, `location.fiber`, `location.position`,
 and `daq.rawid` are filled in for each module. SiPM raw IDs start at 5000.
 
-### `pmts.yaml` — PMT template
+### `pmts.yaml` - PMT template
 
 Provides the template channelmap entry for all PMTs. During compilation, `name`,
 `daq.rawid`, and `location` (including x, y, z coordinates and the PMT
 orientation direction) are filled in. PMT raw IDs start at 6000.
 
-### `pmts_pos.yaml` — PMT placement
+### `pmts_pos.yaml` - PMT placement
 
 Defines the spatial layout of floor and wall PMTs:
 
@@ -131,7 +207,7 @@ wall:
 - `wall`: each entry defines a ring of PMTs at height `z` (in mm) with `n` PMTs
   distributed across the polygon faces.
 
-### `detail.yaml` — Detail level presets
+### `detail.yaml` - Detail level presets
 
 Defines which geometry assemblies are included for each named detail level:
 
@@ -147,21 +223,21 @@ radiogenic:
 ```
 
 Each key is a named preset (e.g. `cosmogenic`, `radiogenic`) selectable via the
-`--detail` CLI option. Assembly values follow the `pygeomtools` assembly detail
-convention (`omit`, `simple`, `stl`, `detailed`, `metadata`, `place`).
+`detail` config key or the `--detail` CLI option. Assembly values follow the
+`pygeomtools` assembly detail convention (`omit`, `simple`, `stl`, `detailed`,
+`metadata`, `place`).
 
-### `crystal.yaml` — Crystal boule profile
+### `crystal.yaml` - Crystal boule profile
 
 Stores the impurity profile and slice offsets for the HPGe crystal boule used as
-the default detector template with the same format as in the metadata. This file
-is used to populate the `characterization` fields of the `hpge.yaml` template.
-It is required to generate the drift-time map used in the post-processing of the
-pulse-shape discrimination.
+the default detector template, with the same format as in the metadata. It is
+required to generate the drift-time map used in the post-processing of the
+pulse-shape discrimination, but is not read by the geometry generation itself.
 
 ## Compilation
 
 The compilation step converts the raw config files into the two runtime objects
-— `special_metadata` and `channelmap` — via `config_compilation.py`.
+- `special_metadata` and `channelmap` - via `config.py`.
 
 **`special_metadata`** contains the detailed spatial layout used for geometry
 placement:
@@ -181,47 +257,57 @@ placement:
 - One entry per PMT with x/y/z position, orientation direction vector, and raw
   ID.
 
-To generate the compiled config from the default raw configs, run:
+`--write-config` writes the result out resolved into an explicit `channelmap`
+and `special_metadata`, together with the effective `detail` and `assemblies`.
 
 ```console
-$ legend-pygeom-l1000 --generate-compiled-config --output-compiled-config config.yaml
+$ legend-pygeom-l1000 --config geom-config.yaml --write-config resolved.yaml
 ```
 
-To use a custom raw config folder:
+The output is itself a valid config file, so it can be edited by hand and fed
+straight back in via `--config`, and it can be written in the same invocation
+that builds the geometry:
 
 ```console
-$ legend-pygeom-l1000 --generate-compiled-config \
-    --input-raw-config-folder /path/to/my/configs \
-    --output-compiled-config config.yaml
+$ legend-pygeom-l1000 --config geom-config.yaml --write-config resolved.yaml l1000.gdml
 ```
-
-The output is a single YAML file with `channelmap` and `special_metadata` as
-top-level keys.
 
 ## Best practices
 
-1. **Start from the raw configs** for high-level structural changes (e.g. number
-   of strings, PMT ring positions). Regenerate the compiled config afterwards.
-   Alternatively, if you want to keep the default raw configs unchanged, copy
-   the raw config folder using the `--copy-raw-configs-into-cwd-folder` flag and
-   pass `--input-raw-config-folder` to use your custom raw configs without
-   modifying the defaults.
-2. **Edit the compiled config** for fine-grained adjustments (e.g. removing
-   individual detectors, overriding a single position or raw ID) without
-   touching the raw files. Generate the config with `--generate-compiled-config`
-   and `--output-compiled-config`.
-3. **Pass the compiled config** to the geometry builder via `--compiled-config`
-   to bypass the compilation step and use your customized values directly:
+1. **Start from `raw_config`** for high-level structural changes (e.g. number of
+   strings, PMT ring positions). Because it is deep-merged over the packaged raw
+   configs, a change is usually a handful of lines in the geometry config file
+   and needs no copy of the defaults:
 
-   ```console
-   $ legend-pygeom-l1000 -V --compiled-config config.yaml output.gdml
+   ```yaml
+   # geom-config.yaml
+   detail: radiogenic
+   raw_config:
+     string:
+       units:
+         n: 10
    ```
 
-Note that `--input-raw-config-folder` is silently ignored when
-`--compiled-config` is provided — the compiled config always takes precedence.
-Keep your custom raw config in a dedicated folder and pass
-`--input-raw-config-folder` so the default configs remain unchanged and the
-variant is self-contained.
+2. **Move to a resolved config** for fine-grained adjustments (e.g. removing
+   individual detectors, overriding a single position or raw ID) that the raw
+   configuration cannot express. Write it out, edit it, and pass it back in:
+
+   ```console
+   $ legend-pygeom-l1000 --config geom-config.yaml --write-config resolved.yaml
+   $ vim resolved.yaml
+   $ legend-pygeom-l1000 -V --config resolved.yaml l1000.gdml
+   ```
+
+3. **Keep `special_metadata` and `channelmap` in separate files** if the inline
+   versions make the config unwieldy. Both keys also accept a path:
+
+   ```yaml
+   special_metadata: ./special_metadata.yaml
+   channelmap: ./channelmap.yaml
+   ```
+
+Since a resolved config carries both compiled objects, `raw_config` no longer
+has any effect on it. It is ignored with a warning if it is left in place.
 
 ## Examples
 
@@ -238,23 +324,22 @@ variant is self-contained.
 :::
 
 A compact geometry with one central cluster of 6 strings is useful for fast test
-simulations or studies that do not require the full array. Edit `array.yaml` in
-a copy of the configs folder to reduce the cluster list to a single entry at the
-origin:
+simulations or studies that do not require the full array. Override the cluster
+list in `array.yaml` with a single entry at the origin:
 
 ```yaml
-# array.yaml
-center:
-  x_in_mm: [0.0]
-  y_in_mm: [0.0]
-radius_in_mm: 213.5
-angle_in_deg: [0, 60, 120, 180, 240, 300]
+# geom-config.yaml
+raw_config:
+  array:
+    center:
+      x_in_mm: [0.0]
+      y_in_mm: [0.0]
 ```
 
-Then compile:
+Then build:
 
 ```console
-$ legend-pygeom-l1000 -V --input-raw-config-folder ./my_configs/
+$ legend-pygeom-l1000 -V --config geom-config.yaml
 ```
 
 This produces 6 strings (`V0101`-`V0608`, 48 HPGe detectors total), 36 SiPM
@@ -277,18 +362,18 @@ To simulate two string clusters placed around their respective centers, set two
 entries in `array.yaml`:
 
 ```yaml
-# array.yaml
-center:
-  x_in_mm: [0.0, 533.7]
-  y_in_mm: [0.0, 184.9]
-radius_in_mm: 213.5
-angle_in_deg: [0, 60, 120, 180, 240, 300]
+# geom-config.yaml
+raw_config:
+  array:
+    center:
+      x_in_mm: [0.0, 533.7]
+      y_in_mm: [0.0, 184.9]
 ```
 
 Compiling this produces 12 strings (`V0101`-`V1208`, 96 HPGe detectors), 72 SiPM
 channels, and the full PMT complement.
 
-### Removing a specific detector or string from the compiled config
+### Removing a specific detector or string from the resolved config
 
 <!-- prettier-ignore -->
 :::{image} images/geom_12_strings_wo_string_7_top.png
@@ -300,10 +385,10 @@ channels, and the full PMT complement.
 :height: 300px
 :::
 
-After compiling, individual detectors can be removed by deleting their entries
-from the `channelmap` and `special_metadata.hpges` sections of the compiled
-YAML. For example, to remove `V0701` (position 1 of string 7) from the 12-string
-config:
+After writing out the resolved config with `--write-config`, individual
+detectors can be removed by deleting their entries from its `channelmap` and
+`special_metadata.hpges` sections. For example, to remove `V0701` (position 1 of
+string 7) from the 12-string config:
 
 1. Delete the `V0701` key from `channelmap`.
 2. Delete the `V0701` key from `special_metadata.hpges`.
@@ -327,11 +412,12 @@ entries in `hpges` in the `special_metadata`.
 
 ### Replacing the default HPGe template with a custom one
 
-To use a custom HPGe template, create a modified copy of `hpge.yaml` with the
-desired geometry and characterization fields. The geometry is defined using the
-standard format of the legend metadata (e.g. the example geometries found in the
-remage
+To use a custom HPGe template, override `hpge` in `raw_config` with the desired
+geometry and characterization fields. The geometry is defined using the standard
+format of the legend metadata (e.g. the example geometries found in the remage
 [tutorial](https://remage.readthedocs.io/en/stable/tutorial.html#experimental-geometry)).
 At the moment, there is only support for using a single geometry template for
 all detectors, though in the future this will be generalized to allow for
-multiple geometries per setup.
+multiple geometries per setup. Per-detector geometries can already be set by
+hand in a resolved config, since each `channelmap` entry carries its own
+`geometry` block.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ requires-python = ">=3.11"
 dependencies = [
     "legend-pygeom-hpges >=0.9.0",
     "legend-pygeom-optics >=0.15",
-    "legend-pygeom-tools >=0.0.25",
+    "legend-pygeom-tools >=0.5.0",
+    "jsonschema",
     "numpy",
     "pint",
     "pyg4ometry",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requires-python = ">=3.11"
 dependencies = [
     "legend-pygeom-hpges >=0.9.0",
     "legend-pygeom-optics >=0.15",
-    "legend-pygeom-tools >=0.5.0",
+    "legend-pygeom-tools >=0.6.0",
     "jsonschema",
     "numpy",
     "pint",

--- a/src/pygeoml1000/__init__.py
+++ b/src/pygeoml1000/__init__.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
 from pygeoml1000._version import version as __version__
+from pygeoml1000.config import load_config, resolve_config
 from pygeoml1000.core import construct
 
-__all__ = ["__version__", "construct"]
+__all__ = [
+    "__version__",
+    "construct",
+    "load_config",
+    "resolve_config",
+]

--- a/src/pygeoml1000/cli.py
+++ b/src/pygeoml1000/cli.py
@@ -25,7 +25,9 @@ def dump_gdml_cli(argv: list[str] | None = None) -> None:
     if args.debug:
         logging.root.setLevel(logging.DEBUG)
 
-    config = load_geometry_config(args)
+    config = None
+    if args.write_config or args.filename is not None or args.visualize or args.write_manifest:
+        config = load_geometry_config(args)
 
     if args.dump_raw_configs:
         folder = copy_raw_configs(args.dump_raw_configs)
@@ -35,7 +37,7 @@ def dump_gdml_cli(argv: list[str] | None = None) -> None:
         log.info("writing resolved config to %s", args.write_config)
         write_config(config, args.write_config)
 
-    if args.filename is None and not args.visualize and not args.write_manifest:
+    if config is None or (args.filename is None and not args.visualize and not args.write_manifest):
         return
 
     vis_scene = {}

--- a/src/pygeoml1000/cli.py
+++ b/src/pygeoml1000/cli.py
@@ -4,19 +4,93 @@ from __future__ import annotations
 
 import argparse
 import logging
-from pathlib import Path
 
 import dbetto
 from pyg4ometry import config as meshconfig
 from pygeomoptics.store import load_user_material_code
 from pygeomtools import detectors, visualization, write_pygeom
 
-from . import _version, config_compilation, core, manifest
+from . import _version, core, manifest
+from .config import DEFAULT_DETAIL, copy_raw_configs, load_config, resolve_config, write_config
 
 log = logging.getLogger(__name__)
 
 
-def dump_gdml_cli() -> None:
+def dump_gdml_cli(argv: list[str] | None = None) -> None:
+    args = _parse_cli_args(argv)
+
+    logging.basicConfig()
+    if args.verbose:
+        logging.getLogger("pygeoml1000").setLevel(logging.DEBUG)
+    if args.debug:
+        logging.root.setLevel(logging.DEBUG)
+
+    config = load_geometry_config(args)
+
+    if args.dump_raw_configs:
+        folder = copy_raw_configs(args.dump_raw_configs)
+        log.info("copied raw config files to %s", folder)
+
+    if args.write_config:
+        log.info("writing resolved config to %s", args.write_config)
+        write_config(config, args.write_config)
+
+    if args.filename is None and not args.visualize and not args.write_manifest:
+        return
+
+    vis_scene = {}
+    if isinstance(args.visualize, str):
+        vis_scene = dbetto.utils.load_dict(args.visualize)
+
+    if vis_scene.get("fine_mesh", False) or args.check_overlaps or args.write_manifest:
+        meshconfig.setGlobalMeshSliceAndStack(100)
+
+    if args.pygeom_optics_plugin:
+        load_user_material_code(args.pygeom_optics_plugin)
+
+    registry = core.construct(config)
+
+    if args.write_manifest:
+        log.info("writing parts manifest to %s", args.write_manifest)
+        manifest.write_manifest(
+            registry,
+            args.write_manifest,
+            detail_level=config["detail"],
+            assemblies=config.get("assemblies"),
+        )
+
+    if args.check_overlaps:
+        msg = "checking for overlaps"
+        log.info(msg)
+        registry.worldVolume.checkOverlaps(recursive=True)
+
+    if args.filename is not None:
+        log.info("exporting GDML geometry to %s", args.filename)
+    write_pygeom(registry, args.filename)
+
+    if args.det_macro_file:
+        detectors.generate_detector_macro(registry, args.det_macro_file)
+
+    if args.vis_macro_file:
+        visualization.generate_color_macro(registry, args.vis_macro_file)
+
+    if args.visualize:
+        log.info("visualizing...")
+        from pygeomtools import viewer
+
+        viewer.visualize(registry, vis_scene)
+
+
+def load_geometry_config(args: argparse.Namespace) -> dict:
+    """Resolve the geometry config selected on the command line.
+
+    Command line arguments take precedence over the config file, which takes precedence over the
+    defaults.
+    """
+    return resolve_config(load_config(args.config), assemblies=args.assemblies, detail=args.detail)
+
+
+def _parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="legend-pygeom-l1000",
         description="%(prog)s command line interface",
@@ -72,49 +146,42 @@ def dump_gdml_cli() -> None:
     # options for geometry generation.
     geom_opts = parser.add_argument_group("geometry options")
     geom_opts.add_argument(
-        "--assemblies",
+        "--config",
         action="store",
-        default=None,
-        help="""Select the assemblies to generate in the output. If specified, changes all unspecified assemblies to 'omit'.""",
+        help="""Select a config file (YAML or JSON) to read the geometry configuration from""",
     )
     geom_opts.add_argument(
-        "--write-manifest",
+        "--assemblies",
         action="store",
-        help="""Filename to write a YAML parts manifest to, listing the material, the number of placements and the total mass of each part in the geometry""",
+        help="""Comma-separated list of assemblies to generate in the output. Each entry can be
+        prefixed by '+' or '-' to add to/remove from the assemblies enabled by the detail level,
+        but either all entries carry an operator or none do.""",
     )
     geom_opts.add_argument(
         "--detail",
         action="store",
-        default="radiogenic",
-        help="""Select the detail level for the setup. (default: %(default)s)""",
+        help=f"""Select the detail level for the setup. (default: {DEFAULT_DETAIL})""",
     )
 
-    config_opts = parser.add_argument_group("config options")
-    config_opts.add_argument(
-        "--copy-raw-configs-into-cwd-folder",
-        action="store_true",
-        help="""Copy the raw config files to the cwd folder. This is useful for creating a custom config file based on the default raw configs. The default raw configs are located in the 'configs' folder of this package.""",
-    )
-    config_opts.add_argument(
-        "--generate-compiled-config",
-        action="store_true",
-        help="""Generate the compiled config file containing the special_metadata and channelmap.""",
-    )
-    config_opts.add_argument(
-        "--output-compiled-config",
+    # output options.
+    out_opts = parser.add_argument_group("output options")
+    out_opts.add_argument(
+        "--write-manifest",
         action="store",
-        default="",
-        help="""Output file for the compiled config file (default is [cwd]/config.yaml).""",
+        help="""Filename to write a YAML parts manifest to, listing the material, the number of placements and the total mass of each part in the geometry""",
     )
-    config_opts.add_argument(
-        "--compiled-config",
-        help="""Use a compiled config file containing the special_metadata and channelmap instead of generating a new geometry. Overrides using the raw config files.""",
-    )
-    config_opts.add_argument(
-        "--input-raw-config-folder",
+    out_opts.add_argument(
+        "--write-config",
         action="store",
-        default="",
-        help="""Folder location of raw input config files (defaults to Path(__file__).parent/configs/).""",
+        help="""Filename to write the resolved config to, i.e. the config with the raw configuration
+        compiled into an explicit channelmap and special_metadata. The result can be edited by hand
+        and fed back in via --config.""",
+    )
+    out_opts.add_argument(
+        "--dump-raw-configs",
+        action="store",
+        help="""Write a copy of the raw config files shipped with this package into a 'configs'
+        folder below the given directory, as a starting point for a custom configuration.""",
     )
     parser.add_argument(
         "filename",
@@ -123,106 +190,17 @@ def dump_gdml_cli() -> None:
         help="""File name for the output GDML geometry.""",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if (
         not args.visualize
         and args.filename is None
-        and not args.generate_compiled_config
-        and not args.copy_raw_configs_into_cwd_folder
         and not args.write_manifest
+        and not args.write_config
+        and not args.dump_raw_configs
     ):
-        parser.error("no output file, no visualization, and no metadata generation specified")
+        parser.error("no output file, no visualization, and no config output specified")
     if (args.vis_macro_file or args.det_macro_file) and args.filename is None:
         parser.error("writing macro file(s) without gdml file is not possible")
 
-    if args.verbose:
-        logging.getLogger("pygeoml1000").setLevel(logging.DEBUG)
-    if args.debug:
-        logging.root.setLevel(logging.DEBUG)
-
-    if args.copy_raw_configs_into_cwd_folder:
-        log.info("copying raw config files to %s", Path.cwd())
-        folder = Path.cwd()
-        try:
-            config_compilation.copy_raw_configs(destination_folder=folder)
-            log.info("raw config files copied successfully")
-        except Exception as e:
-            log.error("failed to copy raw config files: %s", e)
-            return
-
-    if args.generate_compiled_config:
-        log.info("generating default config file")
-        try:
-            config_compilation.setup_config_file(
-                input_config_folder=args.input_raw_config_folder, output_config=args.output_compiled_config
-            )
-            log.info("config file generated successfully")
-        except Exception as e:
-            log.error("failed to generate config file: %s", e)
-            return
-
-    if args.compiled_config and args.input_raw_config_folder:
-        log.warning("input_raw_config_folder is ignored when using a compiled config file")
-
-    config = {}
-    if args.compiled_config:
-        config = dbetto.utils.load_dict(args.compiled_config)
-
-    if (
-        (args.generate_compiled_config or args.copy_raw_configs_into_cwd_folder)
-        and args.filename is None
-        and not args.visualize
-        and not args.write_manifest
-    ):
-        return
-
-    vis_scene = {}
-    if isinstance(args.visualize, str):
-        vis_scene = dbetto.utils.load_dict(args.visualize)
-
-    # the manifest masses are derived from the meshes, and the default discretisation of curved
-    # solids (16 slices) underestimates their volume by ~2.5%.
-    if vis_scene.get("fine_mesh", False) or args.check_overlaps or args.write_manifest:
-        meshconfig.setGlobalMeshSliceAndStack(100)
-
-    # load custom module to change material properties.
-    if args.pygeom_optics_plugin:
-        load_user_material_code(args.pygeom_optics_plugin)
-
-    registry = core.construct(
-        assemblies=args.assemblies.split(",") if args.assemblies else None,
-        detail_level=args.detail,
-        config=config,
-        input_config_folder=args.input_raw_config_folder,
-    )
-
-    if args.write_manifest:
-        log.info("writing parts manifest to %s", args.write_manifest)
-        manifest.write_manifest(
-            registry,
-            args.write_manifest,
-            detail_level=args.detail,
-            assemblies=args.assemblies.split(",") if args.assemblies else None,
-        )
-
-    if args.check_overlaps:
-        msg = "checking for overlaps"
-        log.info(msg)
-        registry.worldVolume.checkOverlaps(recursive=True)
-
-    if args.filename is not None:
-        log.info("exporting GDML geometry to %s", args.filename)
-    write_pygeom(registry, args.filename)
-
-    if args.det_macro_file:
-        detectors.generate_detector_macro(registry, args.det_macro_file)
-
-    if args.vis_macro_file:
-        visualization.generate_color_macro(registry, args.vis_macro_file)
-
-    if args.visualize:
-        log.info("visualizing...")
-        from pygeomtools import viewer
-
-        viewer.visualize(registry, vis_scene)
+    return args

--- a/src/pygeoml1000/config.py
+++ b/src/pygeoml1000/config.py
@@ -2,19 +2,263 @@ from __future__ import annotations
 
 import copy
 import logging
-import shutil
+from collections.abc import Collection
+from importlib import resources
 from pathlib import Path
+from typing import Any
 
-import dbetto
+import jsonschema
 import numpy as np
-import yaml
-
-from . import watertank
+from dbetto import utils
+from pygeomtools.utils import load_dict_from_config
 
 log = logging.getLogger(__name__)
 
+DEFAULT_DETAIL = "radiogenic"
+_RAW_CONFIG_SUFFIXES = (".yaml", ".json")
+#: substring marking a file in the configs folder that is not raw configuration.
+_NOT_RAW_CONFIG = "_schema"
+#: keys consumed by :func:`resolve_config` itself, and hence absent from a resolved config.
+_RESOLVED_KEYS = ("raw_config",)
+#: keys accepted for interoperability with other generators, but without effect here.
+_IGNORED_KEYS = ("public_geom", "metadata_timestamp", "executable")
 
-def calculate_and_place_pmts(channelmap: dict, configs: dbetto.TextDB, rawid_start: int = 6000) -> None:
+
+def raw_config_dir() -> Path:
+    """Directory holding the raw config files shipped with this package."""
+    return Path(str(resources.files("pygeoml1000") / "configs"))
+
+
+def schema_file() -> Path:
+    """The JSON schema the config files are validated against."""
+    return raw_config_dir() / "runtime_config_schema.yaml"
+
+
+def load_config(filename: str | Path | None) -> dict:
+    """Load a config file (YAML or JSON) and validate it against the schema."""
+    if filename is None:
+        return {}
+
+    config = utils.load_dict(str(filename))
+    validate_config(config)
+    return config
+
+
+def validate_config(config: dict) -> None:
+    """Validate a config against the packaged JSON schema.
+
+    The schema does not set ``additionalProperties: false``, so unknown keys pass through
+    unchecked. Only the values of the keys it knows about are validated.
+
+    Raises
+    ------
+    jsonschema.ValidationError
+        if a known key holds a value of the wrong type or shape.
+    """
+    jsonschema.validate(instance=config, schema=utils.load_dict(str(schema_file())))
+
+
+def resolve_config(config: dict | None = None, **cli_overrides: Any) -> dict:
+    """Resolve a config into one that explicitly contains the compiled geometry inputs.
+
+    The returned dict is itself a valid config file: it has ``channelmap`` and
+    ``special_metadata`` filled in, ``assemblies`` expanded into an absolute list, and no
+    ``raw_config`` left to compile. Resolving it again is a no-op.
+
+    Parameters
+    ----------
+    config
+        the config as read from file (or constructed programmatically).
+    cli_overrides
+        values that take precedence over the config file, e.g. ``detail=...`` or
+        ``assemblies=...``. ``None`` means "not specified on the command line".
+    """
+    config = dict(config or {})
+    validate_config(config)
+
+    for key, value in cli_overrides.items():
+        if value is not None:
+            config[key] = value
+
+    for key in _IGNORED_KEYS:
+        if key in config:
+            log.warning("'%s' has no effect on the LEGEND-1000 geometry, ignoring it", key)
+            del config[key]
+
+    is_compiled = "channelmap" in config and "special_metadata" in config
+    if is_compiled and "raw_config" in config:
+        log.warning("'raw_config' is ignored because both 'channelmap' and 'special_metadata' are given")
+
+    # compiling is only needed for the objects that are not given already.
+    compiled = ({}, {}) if is_compiled else generate_dummy_metadata(load_raw_config(config.get("raw_config")))
+    channelmap = load_dict_from_config(config, "channelmap", lambda: compiled[0])
+    special_metadata = load_dict_from_config(config, "special_metadata", lambda: compiled[1])
+
+    resolved = {k: v for k, v in config.items() if k not in _RESOLVED_KEYS}
+    resolved["channelmap"] = convert_to_plain_types(channelmap)
+    resolved["special_metadata"] = convert_to_plain_types(special_metadata)
+
+    detail_level = config.get("detail", DEFAULT_DETAIL)
+    if detail_level not in special_metadata.get("detail", {}):
+        msg = (
+            f"invalid detail level '{detail_level}', "
+            f"available: {', '.join(sorted(special_metadata.get('detail', {})))}"
+        )
+        raise ValueError(msg)
+    resolved["detail"] = detail_level
+
+    assemblies = parse_assemblies(config.get("assemblies"), special_metadata["detail"][detail_level])
+    if assemblies is None:
+        resolved.pop("assemblies", None)
+    else:
+        resolved["assemblies"] = sorted(assemblies)
+
+    return resolved
+
+
+def load_raw_config(raw_config: dict | str | None = None) -> dict:
+    """Load the packaged raw configs, deep-merged with the user's overrides.
+
+    ``raw_config`` is either an inline mapping (keyed by raw config file name without its
+    extension) or the path to a folder of raw config files. In both cases the packaged configs
+    are used as the base, so only the values that actually change have to be given.
+    """
+    configs = _load_raw_config_dir(raw_config_dir())
+
+    if isinstance(raw_config, str):
+        raw_config = _load_raw_config_dir(Path(raw_config))
+    if raw_config:
+        configs = _deep_merge(configs, raw_config)
+
+    return configs
+
+
+def _load_raw_config_dir(path: Path) -> dict:
+    """Load every raw config file in ``path``, keyed by file name without the extension."""
+    if not path.is_dir():
+        msg = f"raw config folder {path} does not exist"
+        raise FileNotFoundError(msg)
+
+    return {f.stem: utils.load_dict(str(f)) for f in sorted(path.iterdir()) if _is_raw_config(f)}
+
+
+def _is_raw_config(path: Path) -> bool:
+    """Whether ``path`` is a raw config file, and not e.g. the JSON schema next to them."""
+    return path.is_file() and path.suffix in _RAW_CONFIG_SUFFIXES and _NOT_RAW_CONFIG not in path.stem
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Recursively merge ``override`` into a copy of ``base``."""
+    merged = copy.deepcopy(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
+def parse_assemblies(arg: str | Collection[str] | None, detail: dict) -> set[str] | None:
+    """Parse the assembly selection into an absolute set of assembly names.
+
+    Parameters
+    ----------
+    arg
+        a comma-separated string or a collection of assembly names. Entries can be prefixed by
+        the set operators ``+`` or ``-`` to add to/remove from the set of assemblies enabled by
+        the detail preset, but either all entries carry an operator or none do. ``None`` (or an
+        empty selection) leaves the detail preset untouched.
+    detail
+        the selected detail preset, i.e. a mapping of assembly name to detail level.
+    """
+    if arg is None:
+        return None
+
+    parts = [a.strip() for a in arg.split(",")] if isinstance(arg, str) else list(arg)
+    parts = [a for a in parts if a != ""]
+    if not parts:
+        return None
+
+    with_no_op = [a[0] not in ("+", "-") for a in parts]
+    if any(with_no_op) and not all(with_no_op):
+        msg = "either all or no assemblies can be prefixed by the operators '+' or '-'"
+        raise ValueError(msg)
+
+    if not any(with_no_op):  # all have operators
+        assemblies = {system for system, level in detail.items() if level != "omit"}
+        for part in parts:
+            if part[0] == "-":
+                assemblies -= {part[1:]}
+            else:
+                assemblies |= {part[1:]}
+    else:
+        assemblies = set(parts)
+
+    unknown = assemblies - set(detail)
+    if unknown != set():
+        msg = f"invalid geometrical assembly specified: {', '.join(sorted(unknown))}"
+        raise ValueError(msg)
+
+    if "cryostat" not in assemblies and {"HPGe_dets", "fiber_curtain"} & assemblies:
+        msg = (
+            "invalid geometrical assembly specified. Cryostat must be included if HPGe_dets or "
+            "fiber_curtain are included"
+        )
+        raise ValueError(msg)
+
+    return assemblies
+
+
+def effective_detail(config: dict) -> dict:
+    """The detail level of each assembly, after applying the assembly selection.
+
+    Assemblies that are not selected are switched to ``omit``. Selected assemblies that the
+    preset omits are switched to ``simple``.
+    """
+    detail = copy.deepcopy(config["special_metadata"]["detail"][config["detail"]])
+
+    assemblies = config.get("assemblies")
+    if assemblies is None:
+        return detail
+
+    for system in detail:
+        if system not in assemblies:
+            detail[system] = "omit"
+    for system in assemblies:
+        if detail[system] == "omit":
+            detail[system] = "simple"
+
+    return detail
+
+
+def write_config(config: dict, filename: str | Path) -> None:
+    """Write a resolved config to a YAML/JSON file that can be fed back in via ``--config``."""
+    utils.write_dict(resolve_config(config), str(filename))
+
+
+def copy_raw_configs(destination: str | Path) -> Path:
+    """Copy the packaged raw config files into a ``configs`` folder below ``destination``.
+
+    Returns the folder the files were written to.
+    """
+    destination = Path(destination) / "configs"
+    destination.mkdir(parents=True, exist_ok=True)
+
+    for item in sorted(raw_config_dir().iterdir()):
+        if _is_raw_config(item):
+            (destination / item.name).write_bytes(item.read_bytes())
+
+    return destination
+
+
+# ----------------------------------------------------------------------------
+# compilation of the raw configuration into channelmap and special_metadata, previously in config_compilation.py
+# ----------------------------------------------------------------------------
+
+
+def calculate_and_place_pmts(channelmap: dict, configs: dict, rawid_start: int = 6000) -> None:
+    from . import watertank  # noqa: PLC0415
+
     # Floor PMTs are pretty trivial to place
     rawid = rawid_start
     for row in configs["pmts_pos"]["floor"].values():
@@ -121,7 +365,7 @@ def calculate_and_place_pmts(channelmap: dict, configs: dbetto.TextDB, rawid_sta
             raise ValueError(msg)
 
 
-def generate_special_metadata(string_idx: list, hpge_names: list, configs: dbetto.TextDB) -> dict:
+def generate_special_metadata(string_idx: list, hpge_names: list, configs: dict) -> dict:
     """Generate special_metadata.yaml file."""
 
     special_output = {}
@@ -193,7 +437,7 @@ def generate_channelmap(
     string_idx: list,
     hpge_names: list,
     hpge_rawid: list,
-    configs: dbetto.TextDB,
+    configs: dict,
     unit_divisor: int = 100,
 ) -> dict:
     """Generate channelmap.json file."""
@@ -243,15 +487,15 @@ def generate_channelmap(
 
 def _round_up(value: int, multiple: int) -> int:
     """Round ``value`` up to the next integer multiple of ``multiple``."""
-    return -(-value // multiple) * multiple
+    return (value // multiple) * multiple
 
 
-def _convert_numpy_types(obj):
-    """Convert numpy types to native Python types recursively."""
+def convert_to_plain_types(obj):
+    """Convert numpy types and dict subclasses to plain Python types, recursively."""
     if isinstance(obj, dict):
-        return {str(key): _convert_numpy_types(value) for key, value in obj.items()}
+        return {str(key): convert_to_plain_types(value) for key, value in obj.items()}
     if isinstance(obj, list):
-        return [_convert_numpy_types(item) for item in obj]
+        return [convert_to_plain_types(item) for item in obj]
     if isinstance(obj, np.integer):
         return int(obj)
     if isinstance(obj, np.floating):
@@ -263,20 +507,20 @@ def _convert_numpy_types(obj):
     return obj
 
 
-def generate_dummy_metadata(input_config_folder: str = "") -> tuple[dict, dict]:
-    """Generate dummy metadata objects without writing files.
+def generate_dummy_metadata(configs: dict) -> tuple[dict, dict]:
+    """Compile the raw configuration into the two objects the geometry is built from.
 
-    Returns:
-        tuple: (channelmap_dict, special_metadata_dict)
+    Parameters
+    ----------
+    configs
+        the raw configuration, keyed by raw config file name without its extension. Use
+        :func:`pygeoml1000.config.load_raw_config` to obtain it.
+
+    Returns
+    -------
+    tuple
+        ``(channelmap, special_metadata)``
     """
-    # Default to configs directory if paths are not provided
-    script_dir = Path(__file__).parent
-    configs_dir = script_dir / "configs"
-    if input_config_folder != "":
-        configs_dir = Path(input_config_folder)
-
-    configs = dbetto.TextDB(configs_dir)
-
     string_idx = np.arange(
         len(configs["array"]["center"]["x_in_mm"]) * len(configs["array"]["angle_in_deg"])
     ).reshape(len(configs["array"]["center"]["x_in_mm"]), len(configs["array"]["angle_in_deg"]))
@@ -297,36 +541,4 @@ def generate_dummy_metadata(input_config_folder: str = "") -> tuple[dict, dict]:
     special_metadata = generate_special_metadata(string_idx, hpge_names, configs)
     channelmap = generate_channelmap(string_idx, hpge_names, hpge_rawid, configs, unit_divisor=10**unit_width)
 
-    # Convert numpy types to native Python types to match file serialization behavior
-    channelmap = _convert_numpy_types(channelmap)
-    special_metadata = _convert_numpy_types(special_metadata)
-
-    return channelmap, special_metadata
-
-
-def setup_config_file(input_config_folder: str = "", output_config: str = "") -> None:
-    """Generate and write dummy metadata files to disk."""
-
-    # Generate the metadata objects
-    channelmap, special_metadata = generate_dummy_metadata(input_config_folder)
-
-    output_dict = {"channelmap": channelmap, "special_metadata": special_metadata}
-
-    if output_config == "":
-        output_config = "config.yaml"
-
-    with Path(output_config).open("w") as f:
-        yaml.dump(output_dict, f)
-
-
-def copy_raw_configs(destination_folder: str) -> None:
-    """Copy raw config files to a custom folder."""
-    script_dir = Path(__file__).parent
-    configs_dir = script_dir / "configs"
-
-    destination_folder = Path(destination_folder)
-    destination_folder.mkdir(parents=True, exist_ok=True)
-
-    for item in configs_dir.iterdir():
-        if item.is_file():
-            shutil.copyfile(item, destination_folder / item.name)
+    return convert_to_plain_types(channelmap), convert_to_plain_types(special_metadata)

--- a/src/pygeoml1000/configs/runtime_config_schema.yaml
+++ b/src/pygeoml1000/configs/runtime_config_schema.yaml
@@ -1,0 +1,62 @@
+"$schema": https://json-schema.org/draft/2020-12/schema
+title: legend-pygeom-l1000 config file
+
+# the key names below are deliberately kept in sync with the legend-pygeom-l200 config schema,
+# so that a legend-simflow geometry config is portable between the two generators.
+type: object
+properties:
+  # --- shared vocabulary with legend-pygeom-l200 ---
+  assemblies:
+    description: >-
+      Assemblies to build. Either an absolute list of assembly names, or a list in which every
+      entry is prefixed by the set operators '+'/'-' to modify the set implied by the detail
+      preset. A comma-separated string is also accepted.
+    anyOf:
+      - type: array
+        items:
+          type: string
+        uniqueItems: true
+      - type: string
+  special_metadata:
+    description: Inline special metadata, or a path to a YAML/JSON file containing it.
+    type: [object, string]
+  channelmap:
+    description: Inline channel map, or a path to a YAML/JSON file containing it.
+    type: [object, string]
+  sipm_use_pde_curve:
+    type: boolean
+  sipm_efficiencies:
+    type: object
+    patternProperties:
+      ".*":
+        type: number
+  public_geom:
+    description: >-
+      Accepted for compatibility with legend-pygeom-l200. LEGEND-1000 has no hardware metadata,
+      so its geometry is always built from public data and this option has no effect.
+    type: boolean
+  metadata_timestamp:
+    description: >-
+      Accepted for compatibility with legend-pygeom-l200, but ignored: LEGEND-1000 has no
+      hardware metadata to select a snapshot from.
+    type: string
+    pattern: "^\\d{8}T\\d{6}Z$"
+
+  # --- consumed by the calling workflow, not by the geometry generation ---
+  executable:
+    description: >-
+      The geometry generator legend-simflow invokes for this config. Declared here so that a
+      simflow geometry config validates. It is ignored by the generation itself.
+    type: string
+
+  # --- legend-pygeom-l1000 specific ---
+  detail:
+    description: Name of the detail level preset to use (a key of the raw ``detail.yaml``).
+    type: string
+  raw_config:
+    description: >-
+      Raw configuration overrides, deep-merged on top of the raw configs shipped with the
+      package. Either an inline mapping (keyed by raw config file name without extension), or a
+      path to a folder of raw config files. Ignored if both ``channelmap`` and
+      ``special_metadata`` are given.
+    type: [object, string]

--- a/src/pygeoml1000/configs/runtime_config_schema.yaml
+++ b/src/pygeoml1000/configs/runtime_config_schema.yaml
@@ -8,9 +8,10 @@ properties:
   # --- shared vocabulary with legend-pygeom-l200 ---
   assemblies:
     description: >-
-      Assemblies to build. Either an absolute list of assembly names, or a list in which every
-      entry is prefixed by the set operators '+'/'-' to modify the set implied by the detail
-      preset. A comma-separated string is also accepted.
+      Assemblies to build. Either an absolute list of assembly names, or a list
+      in which every entry is prefixed by the set operators '+'/'-' to modify
+      the set implied by the detail preset. A comma-separated string is also
+      accepted.
     anyOf:
       - type: array
         items:
@@ -18,10 +19,12 @@ properties:
         uniqueItems: true
       - type: string
   special_metadata:
-    description: Inline special metadata, or a path to a YAML/JSON file containing it.
+    description:
+      Inline special metadata, or a path to a YAML/JSON file containing it.
     type: [object, string]
   channelmap:
-    description: Inline channel map, or a path to a YAML/JSON file containing it.
+    description:
+      Inline channel map, or a path to a YAML/JSON file containing it.
     type: [object, string]
   sipm_use_pde_curve:
     type: boolean
@@ -32,31 +35,34 @@ properties:
         type: number
   public_geom:
     description: >-
-      Accepted for compatibility with legend-pygeom-l200. LEGEND-1000 has no hardware metadata,
-      so its geometry is always built from public data and this option has no effect.
+      Accepted for compatibility with legend-pygeom-l200. LEGEND-1000 has no
+      hardware metadata, so its geometry is always built from public data and
+      this option has no effect.
     type: boolean
   metadata_timestamp:
     description: >-
-      Accepted for compatibility with legend-pygeom-l200, but ignored: LEGEND-1000 has no
-      hardware metadata to select a snapshot from.
+      Accepted for compatibility with legend-pygeom-l200, but ignored:
+      LEGEND-1000 has no hardware metadata to select a snapshot from.
     type: string
     pattern: "^\\d{8}T\\d{6}Z$"
 
   # --- consumed by the calling workflow, not by the geometry generation ---
   executable:
     description: >-
-      The geometry generator legend-simflow invokes for this config. Declared here so that a
-      simflow geometry config validates. It is ignored by the generation itself.
+      The geometry generator legend-simflow invokes for this config. Declared
+      here so that a simflow geometry config validates. It is ignored by the
+      generation itself.
     type: string
 
   # --- legend-pygeom-l1000 specific ---
   detail:
-    description: Name of the detail level preset to use (a key of the raw ``detail.yaml``).
+    description:
+      Name of the detail level preset to use (a key of the raw ``detail.yaml``).
     type: string
   raw_config:
     description: >-
-      Raw configuration overrides, deep-merged on top of the raw configs shipped with the
-      package. Either an inline mapping (keyed by raw config file name without extension), or a
-      path to a folder of raw config files. Ignored if both ``channelmap`` and
-      ``special_metadata`` are given.
+      Raw configuration overrides, deep-merged on top of the raw configs shipped
+      with the package. Either an inline mapping (keyed by raw config file name
+      without extension), or a path to a folder of raw config files. Ignored if
+      both ``channelmap`` and ``special_metadata`` are given.
     type: [object, string]

--- a/src/pygeoml1000/core.py
+++ b/src/pygeoml1000/core.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
 import logging
-from importlib import resources
 from typing import NamedTuple
 
-from dbetto import AttrsDict, TextDB
+from dbetto import AttrsDict
 from pyg4ometry import geant4
 
 from . import (
     cavern_and_labs,
-    config_compilation,
     cryo,
     fibers,
     hpge_strings,
@@ -17,9 +15,9 @@ from . import (
     watertank,
     watertank_instrumentation,
 )
+from .config import effective_detail, resolve_config
 
 logger = logging.getLogger(__name__)
-configs = TextDB(resources.files("pygeoml1000") / "configs")
 
 
 class InstrumentationData(NamedTuple):
@@ -49,50 +47,21 @@ class InstrumentationData(NamedTuple):
     """The chosen detail level by the user. Used to navigate to the corresponding entry in the special metadata."""
 
 
-def construct(
-    assemblies: list[str] | None = None,
-    detail_level: str = "radiogenic",
-    config: dict | None = None,
-    input_config_folder: str = "",
-) -> geant4.Registry:
-    """Construct the LEGEND-1000 geometry and return the pyg4ometry Registry containing the world volume."""
+def construct(config: dict | None = None) -> geant4.Registry:
+    """Construct the LEGEND-1000 geometry and return the pyg4ometry Registry containing the world volume.
 
-    config = config if config is not None else {}
+    Parameters
+    ----------
+    config
+        the runtime configuration, as described in :doc:`/runtime-cfg`. It is resolved with
+        :func:`pygeoml1000.config.resolve_config` first, so both a config as read from file and
+        an already-resolved one are accepted. ``None`` builds the default geometry.
+    """
+    config = resolve_config(config)
 
-    channelmap_dict, special_metadata_dict = config_compilation.generate_dummy_metadata(
-        input_config_folder=input_config_folder
-    )
-
-    if "special_metadata" in config:
-        special_metadata_dict = config["special_metadata"]
-    if "channelmap" in config:
-        channelmap_dict = config["channelmap"]
-
-    special_metadata = AttrsDict(special_metadata_dict)
-    channelmap = AttrsDict(channelmap_dict)
-
-    if detail_level not in special_metadata["detail"]:
-        msg = "invalid detail level specified"
-        raise ValueError(msg)
-
-    detail = special_metadata["detail"][detail_level]
-    if assemblies is not None:
-        if set(assemblies) - set(detail) != set():
-            msg = "invalid geometrical assembly specified"
-            raise ValueError(msg)
-
-        if "cryostat" not in assemblies and {"HPGe_dets", "fiber_curtain"} & set(assemblies):
-            msg = "invalid geometrical assembly specified. Cryostat must be included if HPGe_dets or fiber_curtain are included"
-            raise ValueError(msg)
-
-        for system in detail:
-            if system not in assemblies:
-                detail[system] = "omit"
-
-        # Enable systems that have been specified but are not in the detail level
-        for system in assemblies:
-            if detail[system] == "omit":
-                detail[system] = "simple"
+    special_metadata = AttrsDict(config["special_metadata"])
+    channelmap = AttrsDict(config["channelmap"])
+    detail = AttrsDict(effective_detail(config))
 
     reg = geant4.Registry()
     mats = materials.OpticalMaterialRegistry(reg)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,67 @@
+# ruff: noqa: PLC0415
+
+from __future__ import annotations
+
+import pytest
+from dbetto import utils
+
+
+def test_no_output_requested_errors():
+    from pygeoml1000 import cli
+
+    with pytest.raises(SystemExit):
+        cli.dump_gdml_cli([])
+
+
+def test_write_config_only(tmp_path):
+    """Writing the config must not build the geometry."""
+    from pygeoml1000 import cli, config
+
+    out = tmp_path / "resolved.yaml"
+    cli.dump_gdml_cli(["--write-config", str(out)])
+
+    assert config.load_config(out) == config.resolve_config({})
+
+
+def test_dump_raw_configs(tmp_path):
+    from pygeoml1000 import cli, config
+
+    cli.dump_gdml_cli(["--dump-raw-configs", str(tmp_path)])
+
+    assert (tmp_path / "configs" / "string.yaml").exists()
+    assert utils.load_dict(str(tmp_path / "configs" / "string.yaml")) == config.load_raw_config()["string"]
+
+
+def test_cli_args_override_the_config_file(tmp_path):
+    from pygeoml1000 import cli
+
+    config_file = tmp_path / "geom-config.yaml"
+    utils.write_dict({"detail": "radiogenic", "assemblies": ["cryostat"]}, str(config_file))
+
+    args = cli._parse_cli_args(
+        ["--config", str(config_file), "--detail", "cosmogenic", "--assemblies", "watertank", "out.gdml"]
+    )
+    config = cli.load_geometry_config(args)
+
+    assert config["detail"] == "cosmogenic"
+    assert config["assemblies"] == ["watertank"]
+
+
+def test_build_from_config_file(tmp_path):
+    """The contract legend-simflow relies on: config file in, GDML out."""
+    from pyg4ometry import gdml
+
+    from pygeoml1000 import cli
+
+    config_file = tmp_path / "geom-config.yaml"
+    gdml_file = tmp_path / "l1000.gdml"
+    utils.write_dict(
+        {"assemblies": ["cryostat", "HPGe_dets"], "raw_config": {"string": {"units": {"n": 1}}}},
+        str(config_file),
+    )
+
+    cli.dump_gdml_cli(["--config", str(config_file), str(gdml_file)])
+
+    assert gdml_file.exists()
+    registry = gdml.Reader(gdml_file).getRegistry()
+    assert len(registry.physicalVolumeDict) > 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,235 @@
+# ruff: noqa: PLC0415
+
+from __future__ import annotations
+
+import jsonschema
+import pytest
+from dbetto import utils
+
+
+@pytest.fixture(scope="module")
+def default_config():
+    from pygeoml1000 import config
+
+    return config.resolve_config({})
+
+
+def test_default_is_fully_resolved(default_config):
+    """Resolving an empty config compiles the packaged raw configs."""
+    assert set(default_config) == {"channelmap", "special_metadata", "detail"}
+    assert default_config["detail"] == "radiogenic"
+    assert len(default_config["channelmap"]) > 0
+    assert set(default_config["special_metadata"]) >= {"hpge_string", "hpges", "fibers", "detail"}
+
+
+def test_resolve_is_unchanged(default_config):
+    """A resolved config must survive being fed back in unchanged."""
+    from pygeoml1000 import config
+
+    assert config.resolve_config(default_config) == default_config
+
+
+def test_round_trip_through_file(tmp_path, default_config):
+    from pygeoml1000 import config
+
+    out = tmp_path / "resolved.yaml"
+    config.write_config({}, out)
+
+    assert config.load_config(out) == default_config
+
+
+def test_cli_arguments_take_precedence():
+    from pygeoml1000 import config
+
+    resolved = config.resolve_config({"detail": "radiogenic"}, detail="cosmogenic")
+    assert resolved["detail"] == "cosmogenic"
+
+    # ``None`` means "not specified on the command line", so the config file wins.
+    resolved = config.resolve_config({"detail": "cosmogenic"}, detail=None)
+    assert resolved["detail"] == "cosmogenic"
+
+
+def test_raw_config_is_layered_over_the_defaults():
+    """An inline raw config overrides single values, it does not replace whole files."""
+    from pygeoml1000 import config
+
+    raw = config.load_raw_config({"string": {"units": {"n": 4}}})
+
+    assert raw["string"]["units"]["n"] == 4
+    # everything else in string.yaml survives ...
+    assert raw["string"]["units"]["l"] == 140.1
+    assert raw["string"]["n_sipm_modules_per_string"] == 3
+    # ... and so do the other raw config files.
+    assert raw["array"]["radius_in_mm"] == 213.5
+
+
+def test_raw_config_changes_the_compiled_output():
+    from pygeoml1000 import config
+
+    resolved = config.resolve_config({"raw_config": {"string": {"units": {"n": 4}}}})
+    geds = [ch for ch in resolved["channelmap"].values() if ch["system"] == "geds"]
+
+    assert len(geds) == 4 * len(resolved["special_metadata"]["hpge_string"])
+
+
+def test_raw_config_from_folder(tmp_path):
+    from pygeoml1000 import config
+
+    folder = config.copy_raw_configs(tmp_path)
+    utils.write_dict({"units": {"n": 4}, "n_sipm_modules_per_string": 3}, str(folder / "string.yaml"))
+
+    resolved = config.resolve_config({"raw_config": str(folder)})
+    geds = [ch for ch in resolved["channelmap"].values() if ch["system"] == "geds"]
+
+    assert len(geds) == 4 * len(resolved["special_metadata"]["hpge_string"])
+    assert resolved["special_metadata"]["hpges"]["V0101"]["rodlength_in_mm"] == 140.1
+
+
+def test_compiled_config_skips_compilation(default_config):
+    """With both compiled objects given, the raw configs must not be touched at all."""
+    from pygeoml1000 import config
+
+    resolved = config.resolve_config(
+        {
+            "channelmap": default_config["channelmap"],
+            "special_metadata": default_config["special_metadata"],
+            "raw_config": "/nonexistent",
+        }
+    )
+
+    assert resolved["channelmap"] == default_config["channelmap"]
+    assert "raw_config" not in resolved
+
+
+def test_missing_raw_config_folder_raises():
+    from pygeoml1000 import config
+
+    with pytest.raises(FileNotFoundError):
+        config.resolve_config({"raw_config": "/nonexistent"})
+
+
+@pytest.mark.parametrize(
+    "bad_config",
+    [
+        {"detail": 3},
+        {"sipm_efficiencies": {"S0101T": "not a number"}},
+        {"metadata_timestamp": "yesterday"},
+        {"assemblies": [1, 2]},
+    ],
+)
+def test_schema_rejects(bad_config):
+    from pygeoml1000 import config
+
+    with pytest.raises(jsonschema.ValidationError):
+        config.validate_config(bad_config)
+
+
+def test_workflow_keys_are_accepted(default_config):
+    """A legend-simflow geometry config must validate and build the same geometry.
+
+    ``public_geom``/``metadata_timestamp`` come from the l200 vocabulary, ``executable`` is what
+    simflow uses to pick the generator. None of them mean anything here.
+    """
+    from pygeoml1000 import config
+
+    resolved = config.resolve_config(
+        {
+            "public_geom": True,
+            "metadata_timestamp": "20230311T235840Z",
+            "executable": "legend-pygeom-l1000",
+        }
+    )
+
+    assert resolved == default_config
+
+
+def test_schema_is_not_loaded_as_raw_config():
+    """The schema sits next to the raw configs, but is not one of them."""
+    from pygeoml1000 import config
+
+    assert config.schema_file().parent == config.raw_config_dir()
+    assert "runtime_config_schema" not in config.load_raw_config()
+
+
+@pytest.mark.parametrize("empty", [[], ""])
+def test_empty_assembly_selection_keeps_the_preset(default_config, empty):
+    """An empty selection must not be read as "build nothing"."""
+    from pygeoml1000 import config
+
+    resolved = config.resolve_config({"assemblies": empty})
+
+    assert "assemblies" not in resolved
+    assert config.effective_detail(resolved) == default_config["special_metadata"]["detail"]["radiogenic"]
+
+
+def test_assemblies_set_operators(default_config):
+    from pygeoml1000 import config
+
+    detail = default_config["special_metadata"]["detail"]["radiogenic"]
+    enabled = {system for system, level in detail.items() if level != "omit"}
+
+    assert config.parse_assemblies(None, detail) is None
+    assert config.parse_assemblies("cryostat,HPGe_dets", detail) == {"cryostat", "HPGe_dets"}
+    assert config.parse_assemblies("+watertank", detail) == enabled | {"watertank"}
+    assert config.parse_assemblies(["-fiber_curtain"], detail) == enabled - {"fiber_curtain"}
+
+
+@pytest.mark.parametrize(
+    "assemblies",
+    [
+        "+watertank,cryostat",  # mixing operators and plain names
+        "not_an_assembly",
+        "HPGe_dets",  # HPGe detectors need the cryostat
+    ],
+)
+def test_invalid_assemblies_raise(default_config, assemblies):
+    from pygeoml1000 import config
+
+    with pytest.raises(ValueError, match="assemb"):
+        config.parse_assemblies(assemblies, default_config["special_metadata"]["detail"]["radiogenic"])
+
+
+def test_invalid_detail_level_raises():
+    from pygeoml1000 import config
+
+    with pytest.raises(ValueError, match="invalid detail level"):
+        config.resolve_config({"detail": "not_a_preset"})
+
+
+def test_effective_detail_applies_the_assembly_selection(default_config):
+    from pygeoml1000 import config
+
+    resolved = config.resolve_config(default_config, assemblies="cryostat,HPGe_dets")
+    detail = config.effective_detail(resolved)
+
+    assert detail["cryostat"] != "omit"
+    assert detail["HPGe_dets"] != "omit"
+    assert detail["fiber_curtain"] == "omit"
+
+    # the selection must not leak back into the config it was derived from.
+    assert resolved["special_metadata"]["detail"]["radiogenic"]["fiber_curtain"] != "omit"
+
+
+def test_construct_does_not_mutate_its_config(default_config):
+    """``construct`` used to switch assemblies to 'omit' in the caller's dict."""
+    import copy
+
+    from pygeoml1000 import core
+
+    config_in = {**copy.deepcopy(default_config), "assemblies": ["cryostat"]}
+    before = copy.deepcopy(config_in)
+
+    core.construct(config_in)
+
+    assert config_in == before
+
+
+def test_copy_raw_configs(tmp_path):
+    from pygeoml1000 import config
+
+    folder = config.copy_raw_configs(tmp_path)
+
+    assert folder == tmp_path / "configs"
+    # every raw config is copied, and nothing else - notably not the schema.
+    assert {f.stem for f in folder.iterdir()} == set(config.load_raw_config())
+    assert not (folder / config.schema_file().name).exists()


### PR DESCRIPTION
This PR refactors the config input to align with pygeoml200 and prepares it for use with legend-simflow via a single `simprod/config/geom/l1000xxxyy-geom-config.yaml` config.

Specifically, the executables are adjusted with a single `--config` call with a config. This config can contain either **raw** (`raw_config`) or **compiled** (`channelmap`, `special_metadata`) type information. The former is ignored when both are provided. The provided config can contain the details of all raw configs in a single file and does not have to be distributed across several files. In addition, when the provided raw configs are incomplete, the default options are used for the remaining fields (see docs).

`config.py` replaces `config_compilation.py`, all config related functions (loading, validation, merging, resolving) being contained in it. The validation is performed with JSON Schema similar to pygeoml200.

The config options in the CLI are reduced to `--config`, `--write-config` and `--dump-raw-configs`. `--write-config` provides the resolved configs (compiled) while `--dump-raw-configs` writes the default raw configs into the designated folder. 

In addition, as in pygeoml200, the assemblies cannot also be defined via +/- operations.

