### PR TITLE
docs: add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,30 @@
+cff-version: 1.2.0
+title: legend-pygeom-l1000
+doi: FILL-ME
+date-released: 2026-02-25
+message: "If you use this software, please cite it as below."
+authors:
+  - family-names: Neuberger
+    given-names: Moritz
+    orcid: https://orcid.org/0009-0001-8471-9076
+  - family-names: Huber
+    given-names: Manuel
+    orcid: https://orcid.org/0009-0000-5212-2999
+  - family-names: Pertoldi
+    given-names: Luigi
+    orcid: https://orcid.org/0000-0002-0467-2571
+  - family-names: Esch
+    given-names: Eric
+    orcid: https://orcid.org/0009-0000-4920-9313
+  - family-names: Sánchez García
+    given-names: Edgar
+    orcid: https://orcid.org/0000-0001-8014-4079
+  - family-names: Dixon
+    given-names: Toby
+    orcid: https://orcid.org/0000-0001-8787-6336
+  - family-names: Barton
+    given-names: CJ
+    orcid: https://orcid.org/0000-0002-4698-3765
+  - family-names: Emmanuel
+    given-names: Cedric
+    orcid: https://orcid.org/0009-0002-4274-0376

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,13 @@ name = "legend_pygeom_l1000"
 description = "Geometry model of the LEGEND-1000 experimental setup"
 authors = [
     { name = "Moritz Neuberger", email = "moritz.neuberger@tum.de" },
+    { name = "Manuel Huber", email = "info@manuelhu.de" },
+    { name = "Luigi Pertoldi", email = "gipert@pm.me" },
+    { name = "Eric Esch", email = "eric.esch@student.uni-tuebingen.de" },
+    { name = "Edgar Sánchez García", email = "esanchez@mpi-hd.mpg.de" },
+    { name = "Toby Dixon", email = "tdixon@berkeley.edu" },
+    { name = "CJ Barton", email = "CJ.Barton@coyotes.usd.edu" },
+    { name = "Cedric Emmanuel" },
 ]
 maintainers = [
     { name = "The LEGEND Collaboration" },


### PR DESCRIPTION
Adds `CITATION.cff` following the convention of the other pygeom packages, and syncs `pyproject.toml` `authors` with it. People are listed by number of commits, bots excluded. The Zenodo DOI is still a placeholder.

Two open points: I could not find an ORCID for Edgar Sanchez, and `@cedric-emmanuel` is left out entirely since I could not resolve their real name.